### PR TITLE
[codex] improve local tools and roleplay imports

### DIFF
--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/LocalTools.kt
@@ -23,10 +23,16 @@ import com.eterultimate.eteruee.device.DeviceAgentManager
 import com.eterultimate.eteruee.network.HiddifyCoreManager
 import com.eterultimate.eteruee.utils.readClipboardText
 import com.eterultimate.eteruee.utils.writeClipboardText
+import java.io.InputStream
 import java.time.ZonedDateTime
 import java.time.format.TextStyle
 import java.util.Locale
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 @Serializable
 sealed class LocalToolOption {
@@ -79,7 +85,22 @@ data class ScriptExecutionResult(
 
 private const val QUICKJS_MEMORY_LIMIT = 8 * 1024 * 1024 // 8 MB
 private const val QUICKJS_STACK_SIZE = 256 * 1024 // 256 KB
+private const val QUICKJS_GC_THRESHOLD = 4 * 1024 * 1024 // 4 MB
+private const val MAX_SCRIPT_CODE_CHARS = 200_000
+private const val MAX_SCRIPT_OUTPUT_CHARS = 100_000
+private const val MAX_SCRIPT_LOG_ENTRIES = 200
+private const val MAX_SCRIPT_LOG_CHARS = 4_000
+private const val PYTHON_TIMEOUT_SECONDS = 30L
+private const val PYTHON_BINARY_UNKNOWN = "__unknown__"
+private const val PYTHON_BINARY_MISSING = "__missing__"
 private val quickJsInitialized = AtomicBoolean(false)
+private val pythonBinaryCache = AtomicReference(PYTHON_BINARY_UNKNOWN)
+private val scriptIoThreadIndex = AtomicInteger(0)
+private val scriptIoExecutor = Executors.newCachedThreadPool { runnable ->
+    Thread(runnable, "eteruee-script-io-${scriptIoThreadIndex.incrementAndGet()}").apply {
+        isDaemon = true
+    }
+}
 
 private fun ensureQuickJsInitialized() {
     if (quickJsInitialized.get()) return
@@ -92,6 +113,15 @@ private fun ensureQuickJsInitialized() {
 }
 
 fun executeJavaScriptCode(code: String?): ScriptExecutionResult {
+    val script = code ?: ""
+    if (script.length > MAX_SCRIPT_CODE_CHARS) {
+        return ScriptExecutionResult(
+            result = null,
+            logs = emptyList(),
+            error = "JavaScript code is too large: max $MAX_SCRIPT_CODE_CHARS characters.",
+        )
+    }
+
     val logs = arrayListOf<String>()
     val context = try {
         ensureQuickJsInitialized()
@@ -106,29 +136,31 @@ fun executeJavaScriptCode(code: String?): ScriptExecutionResult {
     return try {
         context.setMemoryLimit(QUICKJS_MEMORY_LIMIT)
         context.setMaxStackSize(QUICKJS_STACK_SIZE)
+        context.setGCThreshold(QUICKJS_GC_THRESHOLD)
+        context.setEnableStackTrace(true)
         context.setConsole(object : QuickJSContext.Console {
             override fun log(info: String?) {
-                logs.add("[LOG] $info")
+                logs.addBoundedLog("[LOG]", info)
             }
 
             override fun info(info: String?) {
-                logs.add("[INFO] $info")
+                logs.addBoundedLog("[INFO]", info)
             }
 
             override fun warn(info: String?) {
-                logs.add("[WARN] $info")
+                logs.addBoundedLog("[WARN]", info)
             }
 
             override fun error(info: String?) {
-                logs.add("[ERROR] $info")
+                logs.addBoundedLog("[ERROR]", info)
             }
         })
-        val result = context.evaluate(code)
+        val result = context.evaluate(script)
         ScriptExecutionResult(
             result = when (result) {
                 null -> null
-                is QuickJSObject -> result.stringify()
-                else -> result.toString()
+                is QuickJSObject -> result.stringify().limitScriptOutput("JavaScript result")
+                else -> result.toString().limitScriptOutput("JavaScript result")
             },
             logs = logs,
             error = null,
@@ -140,11 +172,21 @@ fun executeJavaScriptCode(code: String?): ScriptExecutionResult {
             error = e.message ?: e.javaClass.simpleName,
         )
     } finally {
+        runCatching { context.runGC() }
         context.destroy()
     }
 }
 
 fun executePythonScript(code: String?): ScriptExecutionResult {
+    val script = code ?: ""
+    if (script.length > MAX_SCRIPT_CODE_CHARS) {
+        return ScriptExecutionResult(
+            result = null,
+            logs = emptyList(),
+            error = "Python code is too large: max $MAX_SCRIPT_CODE_CHARS characters.",
+        )
+    }
+
     return try {
         // Try Termux python3 first, then system python3
         val pythonBin = findPythonBinary()
@@ -153,19 +195,38 @@ fun executePythonScript(code: String?): ScriptExecutionResult {
                 logs = emptyList(),
                 error = "Python interpreter not found. Install Python via Termux (pkg install python) or disable the Python tool in settings.",
             )
-        val process = Runtime.getRuntime().exec(arrayOf(pythonBin, "-c", code ?: ""))
+        val process = ProcessBuilder(pythonBin, "-c", script)
+            .apply {
+                environment()["PYTHONIOENCODING"] = "utf-8"
+                environment()["PYTHONUNBUFFERED"] = "1"
+            }
+            .start()
         process.outputStream.close()
 
-        val stdout = process.inputStream.bufferedReader(Charsets.UTF_8).readText()
-        val stderr = process.errorStream.bufferedReader(Charsets.UTF_8).readText()
-        val completed = process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+        val stdoutFuture = scriptIoExecutor.submit(Callable {
+            process.inputStream.readTextLimited(MAX_SCRIPT_OUTPUT_CHARS)
+        })
+        val stderrFuture = scriptIoExecutor.submit(Callable {
+            process.errorStream.readTextLimited(MAX_SCRIPT_OUTPUT_CHARS)
+        })
+
+        val completed = process.waitFor(PYTHON_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 
         if (!completed) {
             process.destroyForcibly()
+            process.waitFor(1, TimeUnit.SECONDS)
+        }
+
+        val stdoutResult = stdoutFuture.getLimitedResult()
+        val stderrResult = stderrFuture.getLimitedResult()
+        val stdout = stdoutResult.toOutputText("stdout")
+        val stderr = stderrResult.toOutputText("stderr")
+
+        if (!completed) {
             return ScriptExecutionResult(
                 result = stdout.ifBlank { null },
                 logs = emptyList(),
-                error = "Python script timed out after 30 seconds.\n$stderr",
+                error = "Python script timed out after ${PYTHON_TIMEOUT_SECONDS} seconds.\n$stderr".trim(),
             )
         }
 
@@ -510,7 +571,84 @@ class LocalTools(
     }
 }
 
+private fun MutableList<String>.addBoundedLog(prefix: String, message: String?) {
+    if (size >= MAX_SCRIPT_LOG_ENTRIES) {
+        if (size == MAX_SCRIPT_LOG_ENTRIES) {
+            add("[TRUNCATED] Console log limited to $MAX_SCRIPT_LOG_ENTRIES entries.")
+        }
+        return
+    }
+    add("$prefix ${(message ?: "null").limitScriptOutput("console log", MAX_SCRIPT_LOG_CHARS)}")
+}
+
+private fun String.limitScriptOutput(
+    label: String,
+    maxChars: Int = MAX_SCRIPT_OUTPUT_CHARS,
+): String {
+    if (length <= maxChars) return this
+    return take(maxChars) + "\n[TRUNCATED] $label limited to $maxChars characters."
+}
+
+private data class LimitedText(
+    val text: String,
+    val truncated: Boolean,
+)
+
+private fun InputStream.readTextLimited(maxChars: Int): LimitedText {
+    var truncated = false
+    val builder = StringBuilder()
+    bufferedReader(Charsets.UTF_8).use { reader ->
+        val buffer = CharArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = reader.read(buffer)
+            if (read < 0) break
+
+            val remaining = maxChars - builder.length
+            if (remaining > 0) {
+                builder.append(buffer, 0, minOf(read, remaining))
+            }
+            if (read > remaining) {
+                truncated = true
+            }
+        }
+    }
+    return LimitedText(builder.toString(), truncated)
+}
+
+private fun java.util.concurrent.Future<LimitedText>.getLimitedResult(): LimitedText {
+    return runCatching {
+        get(1, TimeUnit.SECONDS)
+    }.getOrElse {
+        LimitedText("", truncated = true)
+    }
+}
+
+private fun LimitedText.toOutputText(label: String): String {
+    if (!truncated) return text
+    return text + "\n[TRUNCATED] Python $label limited to $MAX_SCRIPT_OUTPUT_CHARS characters."
+}
+
 private fun findPythonBinary(): String? {
+    when (val cached = pythonBinaryCache.get()) {
+        PYTHON_BINARY_MISSING -> return null
+        PYTHON_BINARY_UNKNOWN -> Unit
+        else -> return cached
+    }
+
+    synchronized(pythonBinaryCache) {
+        when (val cached = pythonBinaryCache.get()) {
+            PYTHON_BINARY_MISSING -> return null
+            PYTHON_BINARY_UNKNOWN -> Unit
+            else -> return cached
+        }
+
+        val discovered = discoverPythonBinary()
+        pythonBinaryCache.set(discovered ?: PYTHON_BINARY_MISSING)
+        return discovered
+    }
+}
+
+private fun discoverPythonBinary(): String? {
     val candidates = listOf(
         "/data/data/com.termux/files/usr/bin/python3",
         "/data/data/com.termux/files/usr/bin/python",
@@ -519,8 +657,15 @@ private fun findPythonBinary(): String? {
     )
     for (bin in candidates) {
         try {
-            val process = Runtime.getRuntime().exec(arrayOf(bin, "--version"))
-            if (process.waitFor() == 0) return bin
+            val process = ProcessBuilder(bin, "--version")
+                .redirectErrorStream(true)
+                .start()
+            val completed = process.waitFor(2, TimeUnit.SECONDS)
+            if (!completed) {
+                process.destroyForcibly()
+            } else if (process.exitValue() == 0) {
+                return bin
+            }
         } catch (_: Exception) {
             // Not available
         }

--- a/app/src/main/java/com/eterultimate/eteruee/di/AppModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/di/AppModule.kt
@@ -20,6 +20,7 @@ import com.eterultimate.eteruee.utils.EmojiUtils
 import com.eterultimate.eteruee.utils.JsonInstant
 import com.eterultimate.eteruee.utils.UpdateChecker
 import com.eterultimate.eteruee.web.WebServerManager
+import com.eterultimate.eteruee.web.relay.HttpRelayService
 import com.eterultimate.eteruee.tts.provider.TTSManager
 import org.koin.dsl.module
 
@@ -83,6 +84,10 @@ val appModule = module {
     }
 
     single {
+        HttpRelayService(okHttpClient = get())
+    }
+
+    single {
         ChatService(
             context = get(),
             appScope = get(),
@@ -108,6 +113,8 @@ val appModule = module {
             conversationRepo = get(),
             settingsStore = get(),
             filesManager = get(),
+            webDavSync = get(),
+            httpRelayService = get(),
             roleplayCharacterService = get(),
             roleplayChatService = get(),
             roleplayGroupService = get(),

--- a/app/src/main/java/com/eterultimate/eteruee/shell/EmbeddedTermuxTerminal.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/shell/EmbeddedTermuxTerminal.kt
@@ -7,6 +7,8 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.termux.terminal.TerminalEmulator
 import com.termux.terminal.TerminalSession
 import com.termux.terminal.TerminalSessionClient
@@ -80,15 +82,12 @@ class EmbeddedTermuxTerminalClient(
     }
 
     override fun onSingleTapUp(e: MotionEvent) {
-        val view = terminalView ?: return
-        view.requestFocus()
-        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-        inputMethodManager?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+        focusAndShowKeyboard(force = true)
     }
 
     override fun shouldBackButtonBeMappedToEscape() = false
 
-    override fun shouldEnforceCharBasedInput() = false
+    override fun shouldEnforceCharBasedInput() = true
 
     override fun shouldUseCtrlSpaceWorkaround() = false
 
@@ -144,7 +143,39 @@ class EmbeddedTermuxTerminalClient(
     override fun logStackTrace(tag: String, e: Exception) {
         Log.e(tag, "Terminal error", e)
     }
+
+    fun focusAndShowKeyboard(force: Boolean = false) {
+        terminalView?.focusAndShowKeyboard(force)
+    }
+
+    fun hideKeyboard() {
+        terminalView?.let { view ->
+            view.context.inputMethodManager()?.hideSoftInputFromWindow(view.windowToken, 0)
+            ViewCompat.getWindowInsetsController(view)?.hide(WindowInsetsCompat.Type.ime())
+        }
+    }
 }
+
+private fun TerminalView.focusAndShowKeyboard(force: Boolean) {
+    isFocusable = true
+    isFocusableInTouchMode = true
+    requestFocus()
+    requestFocusFromTouch()
+    post {
+        requestFocus()
+        requestFocusFromTouch()
+        val inputMethodManager = context.inputMethodManager()
+        inputMethodManager?.restartInput(this)
+        ViewCompat.getWindowInsetsController(this)?.show(WindowInsetsCompat.Type.ime())
+        inputMethodManager?.showSoftInput(
+            this,
+            if (force) InputMethodManager.SHOW_FORCED else InputMethodManager.SHOW_IMPLICIT,
+        )
+    }
+}
+
+private fun Context.inputMethodManager(): InputMethodManager? =
+    getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
 
 fun createEmbeddedTermuxSession(
     context: Context,

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/HighlightCodeBlock.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/HighlightCodeBlock.kt
@@ -111,6 +111,7 @@ fun HighlightCodeBlock(
     val context = LocalContext.current
     val settings = LocalSettings.current
     val colorScheme = MaterialTheme.colorScheme
+    val normalizedLanguage = remember(language) { language.trim().lowercase() }
 
     var isExpanded by remember(settings.displaySetting.codeBlockAutoCollapse) {
         mutableStateOf(!settings.displaySetting.codeBlockAutoCollapse)
@@ -159,30 +160,40 @@ fun HighlightCodeBlock(
                 navController = navController,
                 colorScheme = colorScheme,
                 completeCodeBlock = completeCodeBlock,
+                normalizedLanguage = normalizedLanguage,
                 isExecuting = isExecuting,
                 onExecute = {
                     isExecuting = true
                     showExecResult = true
                     scope.launch(Dispatchers.IO) {
-                        val result = when (language.lowercase()) {
-                            "javascript", "js" -> executeJavaScriptCode(code)
-                            "python", "py" -> executePythonScript(code)
-                            else -> return@launch
-                        }
-                        val output = buildString {
-                            result.result?.let { appendLine(it) }
-                            if (result.logs.isNotEmpty()) {
-                                appendLine("--- Logs ---")
-                                result.logs.forEach { appendLine(it) }
+                        try {
+                            val result = when (normalizedLanguage) {
+                                "javascript", "js" -> executeJavaScriptCode(code)
+                                "python", "py" -> executePythonScript(code)
+                                else -> return@launch
                             }
-                            result.error?.let {
-                                appendLine("--- Error ---")
-                                appendLine(it)
+                            val output = buildString {
+                                result.result?.let { appendLine(it) }
+                                if (result.logs.isNotEmpty()) {
+                                    appendLine("--- Logs ---")
+                                    result.logs.forEach { appendLine(it) }
+                                }
+                                result.error?.let {
+                                    appendLine("--- Error ---")
+                                    appendLine(it)
+                                }
+                            }.trim()
+                            withContext(Dispatchers.Main) {
+                                execResult = output.ifBlank { "No output" }
                             }
-                        }.trim()
-                        withContext(Dispatchers.Main) {
-                            execResult = output.ifBlank { "No output" }
-                            isExecuting = false
+                        } catch (e: Exception) {
+                            withContext(Dispatchers.Main) {
+                                execResult = e.message ?: e.javaClass.simpleName
+                            }
+                        } finally {
+                            withContext(Dispatchers.Main) {
+                                isExecuting = false
+                            }
                         }
                     }
                 },
@@ -192,7 +203,7 @@ fun HighlightCodeBlock(
             modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 8.dp)
         ) {
             when {
-                completeCodeBlock && language == "mermaid" -> {
+                completeCodeBlock && normalizedLanguage == "mermaid" -> {
                     Mermaid(
                         code = code,
                         modifier = Modifier.fillMaxWidth(),
@@ -434,6 +445,7 @@ private fun HighlightCodeActions(
     navController: Navigator,
     colorScheme: ColorScheme = MaterialTheme.colorScheme,
     completeCodeBlock: Boolean = true,
+    normalizedLanguage: String = language.trim().lowercase(),
     isExecuting: Boolean = false,
     onExecute: () -> Unit = {},
 ) {
@@ -464,7 +476,7 @@ private fun HighlightCodeActions(
                 modifier = Modifier
                     .clip(RoundedCornerShape(0.dp))
                     .onClick {
-                        val extension = when (language.lowercase()) {
+                        val extension = when (normalizedLanguage) {
                             "kotlin" -> "kt"
                             "java" -> "java"
                             "python" -> "py"
@@ -509,7 +521,10 @@ private fun HighlightCodeActions(
             )
 
             // Preview button for HTML, SVG, Markdown
-            if (completeCodeBlock && (language == "html" || language == "svg" || language == "markdown" || language == "md")) {
+            if (completeCodeBlock &&
+                (normalizedLanguage == "html" || normalizedLanguage == "svg" ||
+                    normalizedLanguage == "markdown" || normalizedLanguage == "md")
+            ) {
                 Icon(
                     imageVector = HugeIcons.Eye,
                     contentDescription = stringResource(id = R.string.code_block_preview),
@@ -517,7 +532,7 @@ private fun HighlightCodeActions(
                     modifier = Modifier
                         .clip(RoundedCornerShape(0.dp))
                         .onClick {
-                            val content = when (language) {
+                            val content = when (normalizedLanguage) {
                                 "svg" -> {
                                     """<!DOCTYPE html><html><body style="margin:0;display:flex;justify-content:center;align-items:center;min-height:100vh;">$code</body></html>"""
                                 }
@@ -538,7 +553,10 @@ private fun HighlightCodeActions(
             }
 
             // Execute button for JavaScript and Python
-            if (completeCodeBlock && (language == "javascript" || language == "js" || language == "python" || language == "py")) {
+            if (completeCodeBlock &&
+                (normalizedLanguage == "javascript" || normalizedLanguage == "js" ||
+                    normalizedLanguage == "python" || normalizedLanguage == "py")
+            ) {
                 Icon(
                     imageVector = HugeIcons.Play,
                     contentDescription = stringResource(id = R.string.code_block_execute),

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/MarkdownWeb.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/MarkdownWeb.kt
@@ -5,6 +5,9 @@ import androidx.compose.material3.ColorScheme
 import com.eterultimate.eteruee.utils.base64Encode
 import com.eterultimate.eteruee.utils.toCssHex
 
+@Volatile
+private var cachedMarkdownPreviewTemplate: String? = null
+
 /**
  * Build HTML page for markdown preview with support for:
  * - Markdown rendering via marked.js
@@ -13,7 +16,13 @@ import com.eterultimate.eteruee.utils.toCssHex
  * - Syntax highlighting via highlight.js
  */
 fun buildMarkdownPreviewHtml(context: Context, markdown: String, colorScheme: ColorScheme): String {
-    val htmlTemplate = context.assets.open("html/mark.html").bufferedReader().use { it.readText() }
+    val htmlTemplate = cachedMarkdownPreviewTemplate ?: synchronized(::buildMarkdownPreviewHtml) {
+        cachedMarkdownPreviewTemplate ?: context.applicationContext.assets
+            .open("html/mark.html")
+            .bufferedReader()
+            .use { it.readText() }
+            .also { cachedMarkdownPreviewTemplate = it }
+    }
 
     return htmlTemplate
         .replace("{{MARKDOWN_BASE64}}", markdown.base64Encode())

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/webview/WebView.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/webview/WebView.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import android.view.ViewGroup.LayoutParams
 import android.view.inputmethod.InputMethodManager
 import android.webkit.ConsoleMessage
+import android.webkit.WebResourceRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -49,6 +50,11 @@ internal class MyWebChromeClient(private val state: WebViewState) : WebChromeCli
 }
 
 internal class MyWebViewClient(private val state: WebViewState) : WebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val url = request?.url?.toString() ?: return false
+        return state.onUrlRequest?.invoke(url) == true
+    }
+
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
         state.isLoading = true
@@ -111,14 +117,15 @@ fun WebView(
                     setOnTouchListener { view, _ ->
                         view.requestFocus()
                         view.requestFocusFromTouch()
-                        (context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
-                            ?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+                        showInputMethod(context, view)
                         false
                     }
 
                     settings.javaScriptEnabled = true // Enable JavaScript
                     settings.domStorageEnabled = true
-                    settings.allowContentAccess = true
+                    settings.allowContentAccess = false
+                    settings.disableLocalFileAccess()
+                    settings.mediaPlaybackRequiresUserGesture = true
                     settings.apply(state.settings)
 
                     // Use the created clients
@@ -222,7 +229,8 @@ sealed class WebContent {
 class WebViewState(
     initialContent: WebContent = WebContent.NavigatorOnly,
     val interfaces: Map<String, Any> = emptyMap(),
-    val settings: WebSettings.() -> Unit = {}
+    val settings: WebSettings.() -> Unit = {},
+    val onUrlRequest: ((String) -> Boolean)? = null,
 ) {
     // --- Content State ---
     var content: WebContent by mutableStateOf(initialContent)
@@ -326,12 +334,27 @@ fun rememberWebViewState(
     additionalHttpHeaders: Map<String, String> = emptyMap(),
     interfaces: Map<String, Any> = emptyMap(),
     settings: WebSettings.() -> Unit = {},
+    onUrlRequest: ((String) -> Boolean)? = null,
 ) = remember(url, additionalHttpHeaders) { // Use keys for better recomposition control
     WebViewState(
         initialContent = WebContent.Url(url, additionalHttpHeaders),
         interfaces = interfaces,
-        settings = settings
+        settings = settings,
+        onUrlRequest = onUrlRequest,
     )
+}
+
+@Suppress("DEPRECATION")
+private fun showInputMethod(context: Context, view: android.view.View) {
+    (context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
+        ?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+}
+
+@Suppress("DEPRECATION")
+fun WebSettings.disableLocalFileAccess() {
+    allowFileAccess = false
+    allowFileAccessFromFileURLs = false
+    allowUniversalAccessFromFileURLs = false
 }
 
 @Composable
@@ -343,11 +366,13 @@ fun rememberWebViewState(
     historyUrl: String? = null,
     interfaces: Map<String, Any> = emptyMap(),
     settings: WebSettings.() -> Unit = {},
+    onUrlRequest: ((String) -> Boolean)? = null,
 ) = remember(data, baseUrl, encoding, mimeType, historyUrl) { // Use keys
     WebViewState(
         initialContent = WebContent.Data(data, baseUrl, encoding, mimeType, historyUrl),
         interfaces = interfaces,
-        settings = settings
+        settings = settings,
+        onUrlRequest = onUrlRequest,
     )
 }
 

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingMcpPage.kt
@@ -78,12 +78,16 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -109,6 +113,11 @@ import com.eterultimate.eteruee.ui.theme.CustomColors
 import com.eterultimate.eteruee.ui.theme.extendColors
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
+
+private val mcpJson = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+}
 
 @Composable
 fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
@@ -355,7 +364,7 @@ private fun McpServerItem(
 @Composable
 private fun McpServerConfigModal(state: EditState<McpServerConfig>) {
     state.EditStateContent { config, updateValue ->
-        val pagerState = rememberPagerState { 2 }
+        val pagerState = rememberPagerState { 3 }
         val scope = rememberCoroutineScope()
         ModalBottomSheet(
             onDismissRequest = {
@@ -396,6 +405,17 @@ private fun McpServerConfigModal(state: EditState<McpServerConfig>) {
                             Text(stringResource(R.string.setting_mcp_page_tools))
                         }
                     )
+                    Tab(
+                        selected = pagerState.currentPage == 2,
+                        onClick = {
+                            scope.launch {
+                                pagerState.animateScrollToPage(2)
+                            }
+                        },
+                        text = {
+                            Text(stringResource(R.string.setting_mcp_page_json_config))
+                        }
+                    )
                 }
                 HorizontalPager(
                     state = pagerState,
@@ -417,6 +437,13 @@ private fun McpServerConfigModal(state: EditState<McpServerConfig>) {
                                 update = updateValue,
                             )
                         }
+
+                        2 -> {
+                            McpJsonConfigure(
+                                config = config,
+                                update = updateValue,
+                            )
+                        }
                     }
                 }
                 Row(
@@ -433,6 +460,75 @@ private fun McpServerConfigModal(state: EditState<McpServerConfig>) {
                         Text(stringResource(R.string.setting_mcp_page_save))
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun McpJsonConfigure(
+    config: McpServerConfig,
+    update: (McpServerConfig) -> Unit,
+) {
+    var jsonText by remember(config) { mutableStateOf(config.toMcpServersJson()) }
+    var errorMessage by remember(config) { mutableStateOf<String?>(null) }
+    val noValidConfigMsg = stringResource(R.string.setting_mcp_page_import_no_valid_config)
+    val parseErrorMsg = stringResource(R.string.setting_mcp_page_import_parse_error)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .imePadding(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.setting_mcp_page_json_config_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedTextField(
+            value = jsonText,
+            onValueChange = {
+                jsonText = it
+                errorMessage = null
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            placeholder = { Text("{ \"mcpServers\": { ... } }") },
+            isError = errorMessage != null,
+            supportingText = errorMessage?.let { msg -> { Text(msg, color = MaterialTheme.colorScheme.error) } },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+        ) {
+            TextButton(
+                onClick = {
+                    jsonText = config.toMcpServersJson()
+                    errorMessage = null
+                },
+            ) {
+                Text(stringResource(R.string.setting_mcp_page_json_reset))
+            }
+            Button(
+                onClick = {
+                    try {
+                        val parsedConfig = parseSingleMcpServerConfig(jsonText.trim(), config)
+                        if (parsedConfig == null) {
+                            errorMessage = noValidConfigMsg
+                        } else {
+                            update(parsedConfig)
+                            errorMessage = null
+                        }
+                    } catch (e: Exception) {
+                        errorMessage = parseErrorMsg.format(e.message ?: "")
+                    }
+                },
+            ) {
+                Text(stringResource(R.string.setting_mcp_page_json_apply))
             }
         }
     }
@@ -1119,6 +1215,84 @@ private fun parseMcpServersFromJson(json: String): List<McpServerConfig> {
             }
         }
     }
+}
+
+private fun parseSingleMcpServerConfig(json: String, currentConfig: McpServerConfig): McpServerConfig? {
+    val parsedFromMcpServers = parseMcpServersFromJson(json).firstOrNull()
+    if (parsedFromMcpServers != null) {
+        return parsedFromMcpServers.forEditing(currentConfig)
+    }
+
+    val root = Json.parseToJsonElement(json).jsonObject
+    val name = root["name"]?.jsonPrimitive?.contentOrNull
+        ?: currentConfig.commonOptions.name.ifBlank { "MCP Server" }
+    val wrapped = JsonObject(
+        mapOf(
+            "mcpServers" to JsonObject(
+                mapOf(name to root)
+            )
+        )
+    )
+    return parseMcpServersFromJson(mcpJson.encodeToString(JsonObject.serializer(), wrapped))
+        .firstOrNull()
+        ?.forEditing(currentConfig)
+}
+
+private fun McpServerConfig.forEditing(currentConfig: McpServerConfig): McpServerConfig =
+    clone(
+        id = currentConfig.id,
+        commonOptions = commonOptions.copy(
+            enable = currentConfig.commonOptions.enable,
+            tools = currentConfig.commonOptions.tools,
+        ),
+    )
+
+private fun McpServerConfig.toMcpServersJson(): String {
+    val serverName = commonOptions.name.ifBlank { "MCP Server" }
+    val root = JsonObject(
+        mapOf(
+            "mcpServers" to JsonObject(
+                mapOf(serverName to toMcpServerJsonObject())
+            )
+        )
+    )
+    return mcpJson.encodeToString(JsonObject.serializer(), root)
+}
+
+private fun McpServerConfig.toMcpServerJsonObject(): JsonObject {
+    val entries = mutableMapOf<String, JsonElement>()
+    entries["type"] = JsonPrimitive(
+        when (this) {
+            is McpServerConfig.SseTransportServer -> "sse"
+            is McpServerConfig.StreamableHTTPServer -> "streamable_http"
+            is McpServerConfig.StdioTransportServer -> "stdio"
+        }
+    )
+    when (this) {
+        is McpServerConfig.SseTransportServer -> entries["url"] = JsonPrimitive(url)
+        is McpServerConfig.StreamableHTTPServer -> entries["url"] = JsonPrimitive(url)
+        is McpServerConfig.StdioTransportServer -> {
+            entries["command"] = JsonPrimitive(command)
+            if (args.isNotEmpty()) {
+                entries["args"] = JsonArray(args.map { JsonPrimitive(it) })
+            }
+            if (env.any { it.first.isNotBlank() }) {
+                entries["env"] = JsonObject(
+                    env
+                        .filter { it.first.isNotBlank() }
+                        .associate { it.first to JsonPrimitive(it.second) }
+                )
+            }
+        }
+    }
+    if (commonOptions.headers.any { it.first.isNotBlank() }) {
+        entries["headers"] = JsonObject(
+            commonOptions.headers
+                .filter { it.first.isNotBlank() }
+                .associate { it.first to JsonPrimitive(it.second) }
+        )
+    }
+    return JsonObject(entries)
 }
 
 @Composable

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/shell/ShellPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/shell/ShellPage.kt
@@ -1,7 +1,6 @@
 package com.eterultimate.eteruee.ui.pages.shell
 
-import android.content.Context
-import android.view.inputmethod.InputMethodManager
+import android.view.MotionEvent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -24,6 +25,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.composables.icons.lucide.Keyboard
+import com.composables.icons.lucide.Lucide
 import com.eterultimate.eteruee.R
 import com.eterultimate.eteruee.shell.EmbeddedTermuxTerminalClient
 import com.eterultimate.eteruee.shell.LocalShellRunner
@@ -57,6 +60,7 @@ fun ShellPage() {
 
     DisposableEffect(session) {
         onDispose {
+            client.hideKeyboard()
             if (session.pid > 0 && session.isRunning) {
                 session.finishIfRunning()
             }
@@ -78,6 +82,14 @@ fun ShellPage() {
                     }
                 },
                 navigationIcon = { BackButton() },
+                actions = {
+                    IconButton(onClick = { client.focusAndShowKeyboard(force = true) }) {
+                        Icon(
+                            imageVector = Lucide.Keyboard,
+                            contentDescription = stringResource(R.string.shell_page_show_keyboard),
+                        )
+                    }
+                },
             )
         },
     ) { padding ->
@@ -106,18 +118,14 @@ fun ShellPage() {
                             setTerminalViewClient(client)
                             setTextSize(textSizePx.coerceAtLeast(12))
                             attachSession(session)
-                            setOnTouchListener { view, _ ->
-                                view.requestFocus()
-                                view.requestFocusFromTouch()
-                                (viewContext.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
-                                    ?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+                            setOnTouchListener { view, event ->
+                                if (event.action == MotionEvent.ACTION_UP && view is TerminalView && view.hasWindowFocus()) {
+                                    client.focusAndShowKeyboard(force = true)
+                                }
                                 false
                             }
                             post {
-                                requestFocus()
-                                requestFocusFromTouch()
-                                (viewContext.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
-                                    ?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+                                client.focusAndShowKeyboard(force = true)
                             }
                             client.terminalView = this
                         }

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/webview/WebViewPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/webview/WebViewPage.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import me.rerere.hugeicons.stroke.MoreVertical
 import com.eterultimate.eteruee.ui.components.nav.BackButton
 import com.eterultimate.eteruee.ui.components.webview.WebView
+import com.eterultimate.eteruee.ui.components.webview.disableLocalFileAccess
 import com.eterultimate.eteruee.ui.components.webview.rememberWebViewState
 import com.eterultimate.eteruee.ui.theme.JetbrainsMono
 import com.eterultimate.eteruee.utils.base64Decode
@@ -43,12 +44,14 @@ import com.eterultimate.eteruee.utils.base64Decode
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WebViewPage(url: String, content: String) {
+    val uriHandler = LocalUriHandler.current
     val state = if (url.isNotEmpty()) {
         rememberWebViewState(
             url = url,
             settings = {
                 builtInZoomControls = true
                 displayZoomControls = false
+                allowContentAccess = true
             })
     } else {
         rememberWebViewState(
@@ -58,6 +61,16 @@ fun WebViewPage(url: String, content: String) {
             settings = {
                 builtInZoomControls = true
                 displayZoomControls = false
+                allowContentAccess = false
+                disableLocalFileAccess()
+            },
+            onUrlRequest = { requestedUrl ->
+                if (requestedUrl.startsWith("https://eteruee.local")) {
+                    false
+                } else {
+                    runCatching { uriHandler.openUri(requestedUrl) }
+                    true
+                }
             }
         )
     }
@@ -96,7 +109,6 @@ fun WebViewPage(url: String, content: String) {
                         Icon(HugeIcons.ArrowRight01, contentDescription = "Forward")
                     }
 
-                    val urlHandler = LocalUriHandler.current
                     IconButton(
                         onClick = { showDropdown = true }
                     ) {
@@ -113,7 +125,7 @@ fun WebViewPage(url: String, content: String) {
                                     showDropdown = false
                                     state.currentUrl?.let { url ->
                                         if (url.isNotBlank()) {
-                                            urlHandler.openUri(url)
+                                            uriHandler.openUri(url)
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/eterultimate/eteruee/web/WebApiModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/WebApiModule.kt
@@ -25,6 +25,7 @@ import com.eterultimate.eteruee.data.ai.tools.LocalTools
 import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.repository.ConversationRepository
+import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
 import com.eterultimate.eteruee.device.DeviceAgentManager
 import com.eterultimate.eteruee.roleplay.domain.service.CharacterService as RoleplayCharacterService
 import com.eterultimate.eteruee.roleplay.domain.service.ChatService as RoleplayChatService
@@ -33,14 +34,17 @@ import com.eterultimate.eteruee.roleplay.domain.service.PresetService as Rolepla
 import com.eterultimate.eteruee.roleplay.domain.service.WorldInfoService as RoleplayWorldInfoService
 import com.eterultimate.eteruee.service.ChatService
 import com.eterultimate.eteruee.utils.JsonInstant
+import com.eterultimate.eteruee.web.relay.HttpRelayService
 import com.eterultimate.eteruee.web.dto.ErrorResponse
 import com.eterultimate.eteruee.web.dto.WebAuthTokenRequest
 import com.eterultimate.eteruee.web.dto.WebAuthTokenResponse
 import com.eterultimate.eteruee.web.routes.aiIconRoutes
 import com.eterultimate.eteruee.web.routes.assetsRoutes
+import com.eterultimate.eteruee.web.routes.backupRoutes
 import com.eterultimate.eteruee.web.routes.conversationRoutes
 import com.eterultimate.eteruee.web.routes.deviceRoutes
 import com.eterultimate.eteruee.web.routes.filesRoutes
+import com.eterultimate.eteruee.web.routes.relayRoutes
 import com.eterultimate.eteruee.web.routes.roleplayRoutes
 import com.eterultimate.eteruee.web.routes.settingsRoutes
 import java.security.MessageDigest
@@ -72,6 +76,8 @@ fun Application.configureWebApi(
     conversationRepo: ConversationRepository,
     settingsStore: SettingsStore,
     filesManager: FilesManager,
+    webDavSync: WebDavSync,
+    httpRelayService: HttpRelayService,
     roleplayCharacterService: RoleplayCharacterService,
     roleplayChatService: RoleplayChatService,
     roleplayGroupService: RoleplayGroupService,
@@ -188,6 +194,8 @@ fun Application.configureWebApi(
                     settingsRoutes(settingsStore)
                     filesRoutes(filesManager, context)
                     assetsRoutes(context)
+                    backupRoutes(context, settingsStore, webDavSync)
+                    relayRoutes(httpRelayService)
                     roleplayRoutes(
                         aiSDK = aiSDK,
                         settingsStore = settingsStore,
@@ -205,6 +213,8 @@ fun Application.configureWebApi(
                 settingsRoutes(settingsStore)
                 filesRoutes(filesManager, context)
                 assetsRoutes(context)
+                backupRoutes(context, settingsStore, webDavSync)
+                relayRoutes(httpRelayService)
                 roleplayRoutes(
                     aiSDK = aiSDK,
                     settingsStore = settingsStore,

--- a/app/src/main/java/com/eterultimate/eteruee/web/WebServerManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/WebServerManager.kt
@@ -17,6 +17,7 @@ import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.repository.ConversationRepository
 import com.eterultimate.eteruee.data.ai.tools.LocalTools
+import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
 import com.eterultimate.eteruee.device.DeviceAgentManager
 import com.eterultimate.eteruee.roleplay.domain.service.CharacterService as RoleplayCharacterService
 import com.eterultimate.eteruee.roleplay.domain.service.ChatService as RoleplayChatService
@@ -25,6 +26,7 @@ import com.eterultimate.eteruee.roleplay.domain.service.PresetService as Rolepla
 import com.eterultimate.eteruee.roleplay.domain.service.WorldInfoService as RoleplayWorldInfoService
 import com.eterultimate.eteruee.runtime.NativeRuntime
 import com.eterultimate.eteruee.service.ChatService
+import com.eterultimate.eteruee.web.relay.HttpRelayService
 import com.eterultimate.eteruee.web.startWebServer
 
 private const val TAG = "WebServerManager"
@@ -50,6 +52,8 @@ class WebServerManager(
     private val conversationRepo: ConversationRepository,
     private val settingsStore: SettingsStore,
     private val filesManager: FilesManager,
+    private val webDavSync: WebDavSync,
+    private val httpRelayService: HttpRelayService,
     private val roleplayCharacterService: RoleplayCharacterService,
     private val roleplayChatService: RoleplayChatService,
     private val roleplayGroupService: RoleplayGroupService,
@@ -98,6 +102,8 @@ class WebServerManager(
                         conversationRepo = conversationRepo,
                         settingsStore = settingsStore,
                         filesManager = filesManager,
+                        webDavSync = webDavSync,
+                        httpRelayService = httpRelayService,
                         roleplayCharacterService = roleplayCharacterService,
                         roleplayChatService = roleplayChatService,
                         roleplayGroupService = roleplayGroupService,

--- a/app/src/main/java/com/eterultimate/eteruee/web/dto/WebDto.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/dto/WebDto.kt
@@ -120,6 +120,17 @@ data class WebAuthTokenRequest(
     val password: String,
 )
 
+@Serializable
+data class HttpRelayRequest(
+    val url: String,
+    val method: String = "GET",
+    val headers: Map<String, String> = emptyMap(),
+    val body: String? = null,
+    val bodyBase64: String? = null,
+    val contentType: String? = null,
+    val timeoutMillis: Long? = null,
+)
+
 // ========== Response DTOs ==========
 
 @Serializable
@@ -209,6 +220,34 @@ data class MessageSearchResultDto(
 data class WebAuthTokenResponse(
     val token: String,
     val expiresAt: Long,
+)
+
+@Serializable
+data class BackupStatusDto(
+    val lastBackupTime: Long,
+    val webDavConfigured: Boolean,
+    val s3Configured: Boolean,
+    val includedItems: List<String>,
+)
+
+@Serializable
+data class BackupRestoreResponse(
+    val status: String,
+    val fileName: String,
+    val size: Long,
+)
+
+@Serializable
+data class HttpRelayResponse(
+    val url: String,
+    val statusCode: Int,
+    val statusMessage: String,
+    val headers: Map<String, List<String>>,
+    val contentType: String? = null,
+    val body: String? = null,
+    val bodyBase64: String? = null,
+    val bodyEncoding: String,
+    val bodyTruncated: Boolean = false,
 )
 
 // ========== Error Response ==========

--- a/app/src/main/java/com/eterultimate/eteruee/web/relay/HttpRelayService.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/relay/HttpRelayService.kt
@@ -1,0 +1,197 @@
+package com.eterultimate.eteruee.web.relay
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import com.eterultimate.eteruee.web.BadRequestException
+import com.eterultimate.eteruee.web.dto.HttpRelayRequest
+import com.eterultimate.eteruee.web.dto.HttpRelayResponse
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+private const val MAX_RELAY_REQUEST_BODY_BYTES = 5L * 1024 * 1024
+private const val MAX_RELAY_RESPONSE_BODY_BYTES = 10L * 1024 * 1024
+private const val DEFAULT_RELAY_CONTENT_TYPE = "text/plain; charset=utf-8"
+
+private val ALLOWED_RELAY_METHODS = setOf("GET", "POST", "PUT", "PATCH", "DELETE")
+private val METHODS_WITH_REQUIRED_BODY = setOf("POST", "PUT", "PATCH")
+private val BLOCKED_REQUEST_HEADERS = setOf(
+    "connection",
+    "content-length",
+    "content-type",
+    "host",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+)
+
+class HttpRelayService(
+    private val okHttpClient: OkHttpClient,
+) {
+    suspend fun execute(request: HttpRelayRequest): HttpRelayResponse = withContext(Dispatchers.IO) {
+        val targetUrl = request.url.trim().toHttpUrlOrNull()
+            ?: throw BadRequestException("url must be a valid http or https URL")
+        if (targetUrl.scheme !in setOf("http", "https")) {
+            throw BadRequestException("url must be http or https")
+        }
+        if (targetUrl.username.isNotEmpty() || targetUrl.password.isNotEmpty()) {
+            throw BadRequestException("url must not contain credentials")
+        }
+
+        val method = request.method.trim().uppercase(Locale.ROOT)
+        if (method !in ALLOWED_RELAY_METHODS) {
+            throw BadRequestException("Unsupported relay method")
+        }
+
+        val bodyBytes = decodeRequestBody(request)
+        if (method == "GET" && bodyBytes != null) {
+            throw BadRequestException("GET relay requests must not include a body")
+        }
+
+        val mediaType = (request.contentType ?: DEFAULT_RELAY_CONTENT_TYPE).toMediaTypeOrNull()
+        val requestBody = when {
+            bodyBytes != null -> bodyBytes.toRequestBody(mediaType)
+            method in METHODS_WITH_REQUIRED_BODY -> ByteArray(0).toRequestBody(mediaType)
+            else -> null
+        }
+
+        val okRequest = Request.Builder()
+            .url(targetUrl)
+            .apply {
+                request.headers.forEach { (name, value) ->
+                    val normalizedName = validateHeader(name, value)
+                    if (normalizedName.lowercase(Locale.ROOT) !in BLOCKED_REQUEST_HEADERS) {
+                        header(normalizedName, value)
+                    }
+                }
+            }
+            .method(method, requestBody)
+            .build()
+
+        val call = okHttpClient.newCall(okRequest)
+        request.timeoutMillis?.let { timeoutMillis ->
+            if (timeoutMillis !in 1..120_000) {
+                throw BadRequestException("timeoutMillis must be in 1..120000")
+            }
+            call.timeout().timeout(timeoutMillis, TimeUnit.MILLISECONDS)
+        }
+
+        call.execute().use { response ->
+            val bodyResult = readResponseBody(response.body.byteStream())
+            val contentType = response.body.contentType()?.toString()
+                ?: response.header("Content-Type")
+            val isText = shouldReturnText(contentType)
+
+            HttpRelayResponse(
+                url = response.request.url.toString(),
+                statusCode = response.code,
+                statusMessage = response.message,
+                headers = response.headers.toMultimap(),
+                contentType = contentType,
+                body = if (isText) bodyResult.bytes.toString(Charsets.UTF_8) else null,
+                bodyBase64 = if (isText) null else Base64.getEncoder().encodeToString(bodyResult.bytes),
+                bodyEncoding = if (isText) "text" else "base64",
+                bodyTruncated = bodyResult.truncated,
+            )
+        }
+    }
+
+    private fun decodeRequestBody(request: HttpRelayRequest): ByteArray? {
+        if (request.body != null && request.bodyBase64 != null) {
+            throw BadRequestException("Only one of body or bodyBase64 can be provided")
+        }
+
+        val bytes = when {
+            request.body != null -> request.body.toByteArray(Charsets.UTF_8)
+            request.bodyBase64 != null -> try {
+                Base64.getDecoder().decode(request.bodyBase64)
+            } catch (_: IllegalArgumentException) {
+                throw BadRequestException("bodyBase64 is not valid base64")
+            }
+            else -> null
+        }
+
+        if (bytes != null && bytes.size > MAX_RELAY_REQUEST_BODY_BYTES) {
+            throw BadRequestException(
+                "Relay request body too large: max ${MAX_RELAY_REQUEST_BODY_BYTES / (1024 * 1024)} MB"
+            )
+        }
+
+        return bytes
+    }
+
+    private fun validateHeader(name: String, value: String): String {
+        val normalizedName = name.trim()
+        if (normalizedName.isBlank()) {
+            throw BadRequestException("Header name must not be blank")
+        }
+        if (normalizedName.any { it.code <= 31 || it.code == 127 }) {
+            throw BadRequestException("Header name contains invalid characters")
+        }
+        if (value.any { it == '\n' || it == '\r' }) {
+            throw BadRequestException("Header value contains invalid characters")
+        }
+        return normalizedName
+    }
+
+    private fun readResponseBody(input: java.io.InputStream?): RelayBodyResult {
+        if (input == null) {
+            return RelayBodyResult(bytes = ByteArray(0), truncated = false)
+        }
+
+        input.use { stream ->
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var totalBytes = 0L
+            var truncated = false
+
+            while (true) {
+                val read = stream.read(buffer)
+                if (read < 0) break
+
+                val remaining = MAX_RELAY_RESPONSE_BODY_BYTES - totalBytes
+                if (remaining <= 0) {
+                    truncated = true
+                    break
+                }
+
+                val bytesToWrite = minOf(read.toLong(), remaining).toInt()
+                output.write(buffer, 0, bytesToWrite)
+                totalBytes += bytesToWrite
+
+                if (bytesToWrite < read) {
+                    truncated = true
+                    break
+                }
+            }
+
+            return RelayBodyResult(
+                bytes = output.toByteArray(),
+                truncated = truncated,
+            )
+        }
+    }
+
+    private fun shouldReturnText(contentType: String?): Boolean {
+        val normalized = contentType?.lowercase(Locale.ROOT) ?: return false
+        return normalized.startsWith("text/") ||
+            normalized.contains("json") ||
+            normalized.contains("xml") ||
+            normalized.contains("javascript") ||
+            normalized.contains("x-www-form-urlencoded")
+    }
+}
+
+private data class RelayBodyResult(
+    val bytes: ByteArray,
+    val truncated: Boolean,
+)

--- a/app/src/main/java/com/eterultimate/eteruee/web/routes/BackupRoutes.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/routes/BackupRoutes.kt
@@ -1,0 +1,183 @@
+package com.eterultimate.eteruee.web.routes
+
+import android.content.Context
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.PartData
+import io.ktor.server.request.receiveMultipart
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondOutputStream
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
+import com.eterultimate.eteruee.web.BadRequestException
+import com.eterultimate.eteruee.web.dto.BackupRestoreResponse
+import com.eterultimate.eteruee.web.dto.BackupStatusDto
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+private const val BACKUP_CONTENT_TYPE = "application/zip"
+private const val MAX_BACKUP_UPLOAD_SIZE_BYTES = 512L * 1024 * 1024
+
+fun Route.backupRoutes(
+    context: Context,
+    settingsStore: SettingsStore,
+    webDavSync: WebDavSync,
+) {
+    route("/backup") {
+        get("/status") {
+            val settings = settingsStore.settingsFlow.value
+            val s3Configured = settings.s3Config.endpoint.isNotBlank() && settings.s3Config.bucket.isNotBlank()
+            call.respond(
+                BackupStatusDto(
+                    lastBackupTime = settings.backupReminderConfig.lastBackupTime,
+                    webDavConfigured = settings.webDavConfig.url.isNotBlank(),
+                    s3Configured = s3Configured,
+                    includedItems = settings.webDavConfig.items.map { it.name },
+                )
+            )
+        }
+
+        get("/export") {
+            val backupFile = webDavSync.prepareBackupFile(settingsStore.settingsFlow.value.webDavConfig.copy())
+            recordBackupTime(settingsStore)
+
+            call.response.header(
+                HttpHeaders.ContentDisposition,
+                "attachment; filename=\"${backupFile.name}\""
+            )
+            call.response.header(HttpHeaders.ContentLength, backupFile.length().toString())
+            call.respondOutputStream(contentType = ContentType.parse(BACKUP_CONTENT_TYPE)) {
+                try {
+                    FileInputStream(backupFile).use { input ->
+                        input.copyTo(this)
+                    }
+                } finally {
+                    backupFile.delete()
+                }
+            }
+        }
+
+        post("/restore") {
+            val uploadedBackup = call.receiveBackupFile(context)
+            try {
+                webDavSync.restoreFromLocalFile(uploadedBackup.file, settingsStore.settingsFlow.value.webDavConfig)
+                call.respond(
+                    HttpStatusCode.OK,
+                    BackupRestoreResponse(
+                        status = "restored",
+                        fileName = uploadedBackup.fileName,
+                        size = uploadedBackup.size,
+                    )
+                )
+            } finally {
+                uploadedBackup.file.delete()
+            }
+        }
+    }
+}
+
+private suspend fun recordBackupTime(settingsStore: SettingsStore) {
+    settingsStore.update { settings ->
+        settings.copy(
+            backupReminderConfig = settings.backupReminderConfig.copy(
+                lastBackupTime = System.currentTimeMillis()
+            )
+        )
+    }
+}
+
+private data class UploadedBackupFile(
+    val file: File,
+    val fileName: String,
+    val size: Long,
+)
+
+private suspend fun io.ktor.server.application.ApplicationCall.receiveBackupFile(
+    context: Context,
+): UploadedBackupFile {
+    val multipart = receiveMultipart()
+    var uploadedFile: UploadedBackupFile? = null
+
+    while (true) {
+        val part = multipart.readPart() ?: break
+        try {
+            if (part is PartData.FileItem) {
+                if (uploadedFile != null) {
+                    uploadedFile.file.delete()
+                    throw BadRequestException("Only one backup file can be uploaded")
+                }
+
+                val originalFileName = part.originalFileName
+                    ?.takeIf { it.isNotBlank() }
+                    ?: "backup.zip"
+                val fileName = sanitizeBackupFileName(originalFileName)
+                val tempFile = File(context.cacheDir, "web_restore_${System.currentTimeMillis()}_$fileName")
+
+                val size = try {
+                    copyPartToFile(part, tempFile, MAX_BACKUP_UPLOAD_SIZE_BYTES)
+                } catch (e: Throwable) {
+                    tempFile.delete()
+                    throw e
+                }
+                if (size == 0L) {
+                    tempFile.delete()
+                    throw BadRequestException("Uploaded backup file is empty")
+                }
+
+                uploadedFile = UploadedBackupFile(
+                    file = tempFile,
+                    fileName = fileName,
+                    size = size,
+                )
+            }
+        } finally {
+            part.dispose()
+        }
+    }
+
+    return uploadedFile ?: throw BadRequestException("No backup file uploaded")
+}
+
+private suspend fun copyPartToFile(
+    part: PartData.FileItem,
+    file: File,
+    maxBytes: Long,
+): Long = withContext(Dispatchers.IO) {
+    val input = part.provider()
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var totalBytes = 0L
+
+    FileOutputStream(file).use { output ->
+        while (true) {
+            val read = input.readAvailable(buffer, 0, buffer.size)
+            if (read <= 0) break
+
+            totalBytes += read
+            if (totalBytes > maxBytes) {
+                throw BadRequestException("Backup file too large: max ${maxBytes / (1024 * 1024)} MB")
+            }
+
+            output.write(buffer, 0, read)
+        }
+    }
+
+    totalBytes
+}
+
+private fun sanitizeBackupFileName(fileName: String): String {
+    return fileName
+        .substringAfterLast('/')
+        .substringAfterLast('\\')
+        .replace(Regex("[\\u0000-\\u001F\\u007F]"), "")
+        .ifBlank { "backup.zip" }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/web/routes/RelayRoutes.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/routes/RelayRoutes.kt
@@ -1,0 +1,21 @@
+package com.eterultimate.eteruee.web.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import com.eterultimate.eteruee.web.dto.HttpRelayRequest
+import com.eterultimate.eteruee.web.relay.HttpRelayService
+
+fun Route.relayRoutes(
+    relayService: HttpRelayService,
+) {
+    route("/relay") {
+        post("/http") {
+            val request = call.receive<HttpRelayRequest>()
+            call.respond(HttpStatusCode.OK, relayService.execute(request))
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -717,6 +717,10 @@
   <string name="setting_mcp_page_import_no_valid_config">未找到有效的 MCP Server 配置</string>
   <string name="setting_mcp_page_import_parse_error">JSON 解析失敗：%1$s</string>
   <string name="setting_mcp_page_import_title">匯入 MCP Server</string>
+  <string name="setting_mcp_page_json_apply">套用</string>
+  <string name="setting_mcp_page_json_config">JSON 設定</string>
+  <string name="setting_mcp_page_json_config_desc">以標準 mcpServers JSON 編輯目前伺服器。套用 JSON 後會更新目前伺服器設定。</string>
+  <string name="setting_mcp_page_json_reset">重設</string>
   <string name="setting_mcp_page_name">名稱</string>
   <string name="setting_mcp_page_name_desc">MCP伺服器的顯示名稱</string>
   <string name="setting_mcp_page_name_placeholder">例如：My MCP Server</string>
@@ -1105,6 +1109,7 @@
   <string name="shell_page_command_label">命令</string>
   <string name="shell_page_empty_hint">尚未執行任何命令</string>
   <string name="shell_page_execute">執行</string>
+  <string name="shell_page_show_keyboard">開啟輸入法</string>
   <string name="shell_page_termux_output_hint">輸出顯示在Termux終端機中</string>
   <string name="shell_page_title">Shell</string>
   <string name="ssh_page_command_hint">輸入SSH命令...</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -720,6 +720,10 @@
   <string name="setting_mcp_page_import_no_valid_config">未找到有效的 MCP Server 配置</string>
   <string name="setting_mcp_page_import_parse_error">JSON 解析失败：%1$s</string>
   <string name="setting_mcp_page_import_title">导入MCP服务器</string>
+  <string name="setting_mcp_page_json_apply">应用</string>
+  <string name="setting_mcp_page_json_config">JSON 配置</string>
+  <string name="setting_mcp_page_json_config_desc">以标准 mcpServers JSON 编辑当前服务器。应用 JSON 后会更新当前服务器配置。</string>
+  <string name="setting_mcp_page_json_reset">重置</string>
   <string name="setting_mcp_page_name">名称</string>
   <string name="setting_mcp_page_name_desc">MCP服务器的显示名称</string>
   <string name="setting_mcp_page_name_placeholder">例如：My MCP Server</string>
@@ -1110,6 +1114,7 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="shell_page_command_label">命令</string>
   <string name="shell_page_empty_hint">尚未执行任何命令</string>
   <string name="shell_page_execute">执行</string>
+  <string name="shell_page_show_keyboard">打开输入法</string>
   <string name="shell_page_termux_output_hint">输出显示在Termux终端中</string>
   <string name="shell_page_title">Shell</string>
   <string name="ssh_page_command_hint">输入SSH命令...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,6 +720,10 @@
   <string name="setting_mcp_page_import_no_valid_config">No valid MCP Server configuration found</string>
   <string name="setting_mcp_page_import_parse_error">JSON parse failed: %1$s</string>
   <string name="setting_mcp_page_import_title">Import MCP Server</string>
+  <string name="setting_mcp_page_json_apply">Apply</string>
+  <string name="setting_mcp_page_json_config">JSON Config</string>
+  <string name="setting_mcp_page_json_config_desc">Edit this server as standard mcpServers JSON. Applying the JSON updates the current server.</string>
+  <string name="setting_mcp_page_json_reset">Reset</string>
   <string name="setting_mcp_page_name">Name</string>
   <string name="setting_mcp_page_name_desc">Display name for the MCP server</string>
   <string name="setting_mcp_page_name_placeholder">e.g.: My MCP Server</string>
@@ -1109,6 +1113,7 @@
   <string name="shell_page_command_label">Command</string>
   <string name="shell_page_empty_hint">No commands executed yet</string>
   <string name="shell_page_execute">Execute</string>
+  <string name="shell_page_show_keyboard">Show keyboard</string>
   <string name="shell_page_termux_output_hint">Output shown in Termux terminal</string>
   <string name="shell_page_title">Shell</string>
   <string name="ssh_page_command_hint">Enter SSH command...</string>

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/di/RoleplayModule.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/di/RoleplayModule.kt
@@ -83,7 +83,7 @@ val roleplayModule = module {
     single<PromptBuilderService> { PromptBuilderServiceImpl() }
     single<GroupSpeakerService> { GroupSpeakerServiceImpl() }
     single<ExtensionManager> { ExtensionManagerImpl() }
-    single<PresetService> { PresetServiceImpl(get()) }
+    single<PresetService> { PresetServiceImpl(androidContext(), get()) }
     single { RoleplaySubagentExecutor() }
     
     // ViewModels

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/CharacterServiceImpl.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/CharacterServiceImpl.kt
@@ -326,9 +326,10 @@ class CharacterServiceImpl(
 
     private suspend fun importJsonCharacterData(jsonString: String): Result<Character> {
         val character = TavernCharacterCodec.decode(jsonString)
-        fileStorage.saveCharacterJson(character, character.avatarUrl)
-        characterDao.insertCharacter(CharacterEntity.fromModel(character))
-        return Result.success(character)
+        val stored = character.copy(avatarUrl = null)
+        fileStorage.saveCharacterJson(stored, stored.avatarUrl)
+        characterDao.insertCharacter(CharacterEntity.fromModel(stored))
+        return Result.success(stored)
     }
 
     private suspend fun buildPngCharacterBytes(

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/PresetService.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/PresetService.kt
@@ -1,5 +1,6 @@
 package com.eterultimate.eteruee.roleplay.domain.service
 
+import android.net.Uri
 import com.eterultimate.eteruee.roleplay.data.model.Preset
 import com.eterultimate.eteruee.roleplay.data.model.PresetType
 import kotlinx.coroutines.flow.Flow
@@ -63,6 +64,13 @@ interface PresetService {
      * 批量导入预设
      */
     suspend fun importPresets(presets: List<Preset>): Result<Int>
+
+    /**
+     * 导入 Tavern/SillyTavern 生成预设 JSON
+     */
+    suspend fun importPreset(uri: Uri): Result<Preset>
+
+    suspend fun importPreset(jsonString: String, fallbackName: String = "Imported Preset"): Result<Preset>
     
     /**
      * 导出所有预设为JSON

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/PresetServiceImpl.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/PresetServiceImpl.kt
@@ -1,9 +1,12 @@
 package com.eterultimate.eteruee.roleplay.domain.service
 
+import android.content.Context
+import android.net.Uri
 import com.eterultimate.eteruee.roleplay.data.local.dao.PresetDAO
 import com.eterultimate.eteruee.roleplay.data.local.entity.PresetEntity
 import com.eterultimate.eteruee.roleplay.data.model.Preset
 import com.eterultimate.eteruee.roleplay.data.model.PresetType
+import com.eterultimate.eteruee.roleplay.data.tavern.TavernPresetCodec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -13,6 +16,7 @@ import kotlinx.coroutines.withContext
  * 预设服务实现
  */
 class PresetServiceImpl(
+    private val context: Context,
     private val presetDao: PresetDAO
 ) : PresetService {
     
@@ -98,6 +102,34 @@ class PresetServiceImpl(
             }
         }
     }
+
+    override suspend fun importPreset(uri: Uri): Result<Preset> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val jsonString = context.contentResolver.openInputStream(uri)?.use { input ->
+                    input.bufferedReader().readText()
+                } ?: return@withContext Result.failure(Exception("Cannot read file"))
+                val fallbackName = uri.lastPathSegment
+                    ?.substringAfterLast('/')
+                    ?.substringBeforeLast('.')
+                    ?.takeIf { it.isNotBlank() }
+                    ?: "Imported Preset"
+                importPresetData(jsonString, fallbackName)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun importPreset(jsonString: String, fallbackName: String): Result<Preset> {
+        return withContext(Dispatchers.IO) {
+            try {
+                importPresetData(jsonString, fallbackName)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
     
     override suspend fun exportAllPresets(): Result<String> {
         return withContext(Dispatchers.IO) {
@@ -109,5 +141,11 @@ class PresetServiceImpl(
                 Result.failure(e)
             }
         }
+    }
+
+    private suspend fun importPresetData(jsonString: String, fallbackName: String): Result<Preset> {
+        val preset = TavernPresetCodec.decode(jsonString, fallbackName)
+        presetDao.insertPreset(PresetEntity.fromModel(preset))
+        return Result.success(preset)
     }
 }

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/WorldInfoService.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/WorldInfoService.kt
@@ -1,5 +1,6 @@
 package com.eterultimate.eteruee.roleplay.domain.service
 
+import android.net.Uri
 import com.eterultimate.eteruee.roleplay.data.model.WorldInfo
 import com.eterultimate.eteruee.roleplay.data.model.WorldInfoEntry
 import kotlinx.coroutines.flow.Flow
@@ -27,6 +28,13 @@ interface WorldInfoService {
      * 保存完整世界书(创建或更新)
      */
     suspend fun saveWorldInfo(worldInfo: WorldInfo): Result<WorldInfo>
+
+    /**
+     * 导入 Tavern/SillyTavern 世界书 JSON
+     */
+    suspend fun importWorldInfo(uri: Uri): Result<WorldInfo>
+
+    suspend fun importWorldInfo(jsonString: String, fallbackName: String = "Imported Lorebook"): Result<WorldInfo>
     
     /**
      * 更新世界书

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/WorldInfoServiceImpl.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/domain/service/WorldInfoServiceImpl.kt
@@ -1,10 +1,12 @@
 package com.eterultimate.eteruee.roleplay.domain.service
 
 import android.content.Context
+import android.net.Uri
 import com.eterultimate.eteruee.roleplay.data.local.RolePlayFileStorage
 import com.eterultimate.eteruee.roleplay.data.local.dao.WorldInfoDAO
 import com.eterultimate.eteruee.roleplay.data.local.entity.WorldInfoEntity
 import com.eterultimate.eteruee.roleplay.data.model.*
+import com.eterultimate.eteruee.roleplay.data.tavern.TavernWorldInfoCodec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -63,6 +65,36 @@ class WorldInfoServiceImpl(
     override suspend fun saveWorldInfo(worldInfo: WorldInfo): Result<WorldInfo> {
         return updateWorldInfo(worldInfo)
     }
+
+    override suspend fun importWorldInfo(uri: Uri): Result<WorldInfo> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val jsonString = context.contentResolver.openInputStream(uri)?.use { input ->
+                    input.bufferedReader().readText()
+                } ?: return@withContext Result.failure(Exception("Cannot read file"))
+                val fallbackName = uri.lastPathSegment
+                    ?.substringAfterLast('/')
+                    ?.substringBeforeLast('.')
+                    ?.takeIf { it.isNotBlank() }
+                    ?: "Imported Lorebook"
+                importWorldInfoData(jsonString, fallbackName)
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun importWorldInfo(jsonString: String, fallbackName: String): Result<WorldInfo> {
+        return withContext(Dispatchers.IO) {
+            try {
+                importWorldInfoData(jsonString, fallbackName)
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Result.failure(e)
+            }
+        }
+    }
     
     override suspend fun updateWorldInfo(worldInfo: WorldInfo): Result<WorldInfo> {
         return withContext(Dispatchers.IO) {
@@ -82,6 +114,14 @@ class WorldInfoServiceImpl(
                 Result.failure(e)
             }
         }
+    }
+
+    private suspend fun importWorldInfoData(jsonString: String, fallbackName: String): Result<WorldInfo> {
+        val worldInfo = TavernWorldInfoCodec.decode(jsonString, fallbackName)
+        val entity = WorldInfoEntity.fromModel(worldInfo)
+        worldInfoDao.insertWorldInfo(entity)
+        fileStorage.saveWorldInfoJson(worldInfo)
+        return Result.success(worldInfo)
     }
     
     override suspend fun deleteWorldInfo(worldInfoId: Uuid): Result<Unit> {

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/character/CharacterListPage.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/character/CharacterListPage.kt
@@ -1,5 +1,7 @@
 package com.eterultimate.eteruee.roleplay.ui.pages.character
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -14,7 +16,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Sort
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -52,6 +54,17 @@ fun CharacterListPage(
     var searchQuery by remember { mutableStateOf("") }
     var isSearching by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var showImportMenu by remember { mutableStateOf(false) }
+    val pngImportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let(viewModel::importPngCharacter)
+    }
+    val jsonImportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let(viewModel::importJsonCharacter)
+    }
     
     // 加载可用标签
     LaunchedEffect(Unit) {
@@ -152,6 +165,30 @@ fun CharacterListPage(
                             }
                         }) {
                             Icon(Icons.Default.Search, contentDescription = "搜索")
+                        }
+                        Box {
+                            IconButton(onClick = { showImportMenu = true }) {
+                                Icon(Icons.Default.Upload, contentDescription = "导入角色")
+                            }
+                            DropdownMenu(
+                                expanded = showImportMenu,
+                                onDismissRequest = { showImportMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("导入 PNG 角色卡") },
+                                    onClick = {
+                                        showImportMenu = false
+                                        pngImportLauncher.launch(arrayOf("image/png"))
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("导入 JSON 角色卡") },
+                                    onClick = {
+                                        showImportMenu = false
+                                        jsonImportLauncher.launch(arrayOf("application/json", "text/json", "text/plain"))
+                                    }
+                                )
+                            }
                         }
                         IconButton(onClick = onCreateCharacter) {
                             Icon(Icons.Default.Add, contentDescription = "创建角色")

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/preset/PresetListPage.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/preset/PresetListPage.kt
@@ -1,5 +1,7 @@
 package com.eterultimate.eteruee.roleplay.ui.pages.preset
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -52,12 +55,23 @@ fun PresetListPage(
     viewModel: PresetListViewModel = koinViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let(viewModel::importPreset)
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("预设") },
                 actions = {
+                    IconButton(
+                        onClick = { importLauncher.launch(arrayOf("application/json", "text/json", "text/plain")) },
+                        enabled = !uiState.isImporting
+                    ) {
+                        Icon(Icons.Default.Upload, contentDescription = "导入预设")
+                    }
                     IconButton(onClick = onCreatePreset) {
                         Icon(Icons.Default.Add, contentDescription = "创建预设")
                     }
@@ -80,6 +94,18 @@ fun PresetListPage(
                     }
                 ) {
                     Text(error)
+                }
+            }
+            uiState.successMessage?.let { success ->
+                Snackbar(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    action = {
+                        TextButton(onClick = { viewModel.clearMessage() }) {
+                            Text("关闭")
+                        }
+                    }
+                ) {
+                    Text(success)
                 }
             }
 
@@ -128,8 +154,18 @@ fun PresetListPage(
                             Spacer(modifier = Modifier.height(12.dp))
                             Text("暂无预设", style = MaterialTheme.typography.titleMedium)
                             Spacer(modifier = Modifier.height(8.dp))
-                            TextButton(onClick = onCreatePreset) {
-                                Text("创建第一个预设")
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                TextButton(onClick = onCreatePreset) {
+                                    Text("创建第一个预设")
+                                }
+                                TextButton(
+                                    onClick = {
+                                        importLauncher.launch(arrayOf("application/json", "text/json", "text/plain"))
+                                    },
+                                    enabled = !uiState.isImporting
+                                ) {
+                                    Text(if (uiState.isImporting) "导入中..." else "导入预设")
+                                }
                             }
                         }
                     }

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/worldinfo/WorldInfoListPage.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/pages/worldinfo/WorldInfoListPage.kt
@@ -1,5 +1,7 @@
 package com.eterultimate.eteruee.roleplay.ui.pages.worldinfo
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -7,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -28,12 +31,23 @@ fun WorldInfoListPage(
     viewModel: WorldInfoListViewModel = koinViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let(viewModel::importWorldInfo)
+    }
     
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("世界书") },
                 actions = {
+                    IconButton(
+                        onClick = { importLauncher.launch(arrayOf("application/json", "text/json", "text/plain")) },
+                        enabled = !uiState.isImporting
+                    ) {
+                        Icon(Icons.Default.Upload, contentDescription = "导入世界书")
+                    }
                     IconButton(onClick = onCreateWorldInfo) {
                         Icon(Icons.Default.Add, contentDescription = "创建世界书")
                     }
@@ -41,35 +55,72 @@ fun WorldInfoListPage(
             )
         }
     ) { paddingValues ->
-        if (uiState.worldInfos.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("暂无世界书", style = MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(onClick = onCreateWorldInfo) {
-                        Text("创建第一个世界书")
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            uiState.errorMessage?.let { error ->
+                Snackbar(
+                    modifier = Modifier.padding(8.dp),
+                    action = {
+                        TextButton(onClick = { viewModel.clearMessage() }) {
+                            Text("关闭")
+                        }
                     }
+                ) {
+                    Text(error)
                 }
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentPadding = PaddingValues(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(uiState.worldInfos) { worldInfo ->
-                    WorldInfoCard(
-                        worldInfo = worldInfo,
-                        onClick = { onWorldInfoClick(worldInfo) },
-                        onDeleteClick = { viewModel.deleteWorldInfo(worldInfo.id) }
-                    )
+            uiState.successMessage?.let { success ->
+                Snackbar(
+                    modifier = Modifier.padding(8.dp),
+                    action = {
+                        TextButton(onClick = { viewModel.clearMessage() }) {
+                            Text("关闭")
+                        }
+                    }
+                ) {
+                    Text(success)
+                }
+            }
+
+            if (uiState.worldInfos.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("暂无世界书", style = MaterialTheme.typography.titleMedium)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(onClick = onCreateWorldInfo) {
+                                Text("创建第一个世界书")
+                            }
+                            OutlinedButton(
+                                onClick = {
+                                    importLauncher.launch(arrayOf("application/json", "text/json", "text/plain"))
+                                },
+                                enabled = !uiState.isImporting
+                            ) {
+                                Text(if (uiState.isImporting) "导入中..." else "导入世界书")
+                            }
+                        }
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.worldInfos) { worldInfo ->
+                        WorldInfoCard(
+                            worldInfo = worldInfo,
+                            onClick = { onWorldInfoClick(worldInfo) },
+                            onDeleteClick = { viewModel.deleteWorldInfo(worldInfo.id) }
+                        )
+                    }
                 }
             }
         }

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/CharacterListViewModel.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/CharacterListViewModel.kt
@@ -147,6 +147,28 @@ class CharacterListViewModel(
             }
         }
     }
+
+    /**
+     * 导入JSON角色卡
+     */
+    fun importJsonCharacter(uri: Uri) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isImporting = true)
+
+            val result = characterService.importJsonCharacter(uri)
+            result.onSuccess {
+                _uiState.value = _uiState.value.copy(
+                    successMessage = "角色导入成功",
+                    isImporting = false
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    errorMessage = error.message,
+                    isImporting = false
+                )
+            }
+        }
+    }
     
     /**
      * 切换多选模式

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/PresetListViewModel.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/PresetListViewModel.kt
@@ -1,5 +1,6 @@
 package com.eterultimate.eteruee.roleplay.ui.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eterultimate.eteruee.roleplay.data.model.Preset
@@ -41,8 +42,26 @@ class PresetListViewModel(
         }
     }
 
+    fun importPreset(uri: Uri) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isImporting = true)
+
+            presetService.importPreset(uri).onSuccess { preset ->
+                _uiState.value = _uiState.value.copy(
+                    isImporting = false,
+                    successMessage = "已导入预设：${preset.name.ifBlank { "未命名" }}"
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    isImporting = false,
+                    errorMessage = "导入失败: ${error.message}"
+                )
+            }
+        }
+    }
+
     fun clearMessage() {
-        _uiState.value = _uiState.value.copy(errorMessage = null)
+        _uiState.value = _uiState.value.copy(errorMessage = null, successMessage = null)
     }
 }
 
@@ -50,7 +69,9 @@ data class PresetListUiState(
     val presets: List<Preset> = emptyList(),
     val selectedType: PresetType? = null,
     val isLoading: Boolean = true,
-    val errorMessage: String? = null
+    val isImporting: Boolean = false,
+    val errorMessage: String? = null,
+    val successMessage: String? = null
 ) {
     val filteredPresets: List<Preset>
         get() = selectedType?.let { type -> presets.filter { it.type == type } } ?: presets

--- a/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/WorldInfoListViewModel.kt
+++ b/roleplay/src/main/java/com/eterultimate/eteruee/roleplay/ui/viewmodel/WorldInfoListViewModel.kt
@@ -1,5 +1,6 @@
 package com.eterultimate.eteruee.roleplay.ui.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eterultimate.eteruee.roleplay.data.model.WorldInfo
@@ -69,12 +70,33 @@ class WorldInfoListViewModel(
             }
         }
     }
+
+    /**
+     * 导入世界书 JSON
+     */
+    fun importWorldInfo(uri: Uri) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isImporting = true)
+
+            worldInfoService.importWorldInfo(uri).onSuccess { worldInfo ->
+                _uiState.value = _uiState.value.copy(
+                    isImporting = false,
+                    successMessage = "已导入世界书：${worldInfo.name.ifBlank { "未命名" }}"
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    isImporting = false,
+                    errorMessage = "导入失败: ${error.message}"
+                )
+            }
+        }
+    }
     
     /**
      * 清除错误消息
      */
-    fun clearError() {
-        _uiState.value = _uiState.value.copy(errorMessage = null)
+    fun clearMessage() {
+        _uiState.value = _uiState.value.copy(errorMessage = null, successMessage = null)
     }
 }
 
@@ -84,5 +106,7 @@ class WorldInfoListViewModel(
 data class WorldInfoListUiState(
     val worldInfos: List<WorldInfo> = emptyList(),
     val isLoading: Boolean = true,
-    val errorMessage: String? = null
+    val isImporting: Boolean = false,
+    val errorMessage: String? = null,
+    val successMessage: String? = null
 )

--- a/roleplay/src/test/java/com/eterultimate/eteruee/roleplay/data/tavern/TavernImportSampleTest.kt
+++ b/roleplay/src/test/java/com/eterultimate/eteruee/roleplay/data/tavern/TavernImportSampleTest.kt
@@ -1,0 +1,55 @@
+package com.eterultimate.eteruee.roleplay.data.tavern
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+
+class TavernImportSampleTest {
+    @Test
+    fun `decode provided world info sample`() {
+        val file = File("C:/Users/zacza/Desktop/card/工具/性格逻辑世界书3.0.json")
+        assumeTrue("sample file is only available on the user's machine", file.exists())
+
+        val worldInfo = TavernWorldInfoCodec.decode(file.readText(Charsets.UTF_8), "性格逻辑世界书3.0")
+
+        assertTrue(worldInfo.entries.isNotEmpty())
+        assertTrue(worldInfo.entries.any { it.content.isNotBlank() })
+    }
+
+    @Test
+    fun `decode provided preset sample`() {
+        val file = File("C:/Users/zacza/Desktop/card/工具/🚧🥣料碟預設_內部測試.json")
+        assumeTrue("sample file is only available on the user's machine", file.exists())
+
+        val preset = TavernPresetCodec.decode(file.readText(Charsets.UTF_8), "料碟預設")
+
+        assertTrue(preset.name.isNotBlank())
+        assertTrue(preset.parameters.isNotEmpty())
+    }
+
+    @Test
+    fun `decode provided character json sample`() {
+        val file = File("C:/Users/zacza/Desktop/card/涌流/涌流角色卡.json")
+        assumeTrue("sample file is only available on the user's machine", file.exists())
+
+        val character = TavernCharacterCodec.decode(file.readText(Charsets.UTF_8))
+
+        assertTrue(character.name.isNotBlank())
+        assertTrue(character.description.isNotBlank() || character.firstMessage.isNotBlank())
+    }
+
+    @Test
+    fun `decode provided character png sample`() {
+        val file = File("C:/Users/zacza/Desktop/card/工具/角色卡架构师.png")
+        assumeTrue("sample file is only available on the user's machine", file.exists())
+
+        val json = TavernPngCodec.readCharacterJson(file.readBytes())
+        val character = json?.let(TavernCharacterCodec::decode)
+
+        assertNotNull(json)
+        assertNotNull(character)
+        assertTrue(character!!.name.isNotBlank())
+    }
+}

--- a/web-ui/app/services/api.ts
+++ b/web-ui/app/services/api.ts
@@ -154,6 +154,13 @@ const api = {
       return handleError(error);
     }
   },
+  async getBlob(url: string, options?: Options): Promise<Blob> {
+    try {
+      return await kyInstance.get(url, options).blob();
+    } catch (error) {
+      return handleError(error);
+    }
+  },
   async post<T>(url: string, data?: unknown, options?: Options): Promise<T> {
     try {
       return await kyInstance.post(url, { ...options, json: data }).json<T>();

--- a/web-ui/app/services/backup.ts
+++ b/web-ui/app/services/backup.ts
@@ -1,0 +1,16 @@
+import api from "~/services/api";
+import type { BackupRestoreResponse, BackupStatusDto } from "~/types";
+
+export function getBackupStatus(): Promise<BackupStatusDto> {
+  return api.get<BackupStatusDto>("backup/status");
+}
+
+export function exportBackup(): Promise<Blob> {
+  return api.getBlob("backup/export");
+}
+
+export function restoreBackup(file: File): Promise<BackupRestoreResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  return api.postMultipart<BackupRestoreResponse>("backup/restore", formData);
+}

--- a/web-ui/app/services/relay.ts
+++ b/web-ui/app/services/relay.ts
@@ -1,0 +1,6 @@
+import api from "~/services/api";
+import type { HttpRelayRequest, HttpRelayResponse } from "~/types";
+
+export function relayHttp(request: HttpRelayRequest): Promise<HttpRelayResponse> {
+  return api.post<HttpRelayResponse>("relay/http", request);
+}

--- a/web-ui/app/types/dto.ts
+++ b/web-ui/app/types/dto.ts
@@ -30,6 +30,41 @@ export interface UploadFilesResponseDto {
   files: UploadedFileDto[];
 }
 
+export interface BackupStatusDto {
+  lastBackupTime: number;
+  webDavConfigured: boolean;
+  s3Configured: boolean;
+  includedItems: string[];
+}
+
+export interface BackupRestoreResponse {
+  status: string;
+  fileName: string;
+  size: number;
+}
+
+export interface HttpRelayRequest {
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  bodyBase64?: string | null;
+  contentType?: string | null;
+  timeoutMillis?: number | null;
+}
+
+export interface HttpRelayResponse {
+  url: string;
+  statusCode: number;
+  statusMessage: string;
+  headers: Record<string, string[]>;
+  contentType?: string | null;
+  body?: string | null;
+  bodyBase64?: string | null;
+  bodyEncoding: "text" | "base64" | string;
+  bodyTruncated: boolean;
+}
+
 export interface ConversationListInvalidateEventDto {
   type: "invalidate";
   assistantId: string;


### PR DESCRIPTION
## Summary
- add roleplay character/world book/preset import wiring with sample coverage
- harden JavaScript/Python local execution output limits and process handling
- add MCP JSON config editing, web backup/relay routes, and web-ui API clients
- improve shell input focus handling and HTML/rich text rendering behavior

## Validation
- `./gradlew.bat :roleplay:testDebugUnitTest :app:assembleDebug --no-daemon`
- Android emulator smoke test for JSON character, PNG character, world book, and preset imports

## Summary by Sourcery

Add JSON-based MCP server configuration editing, expand roleplay import capabilities, harden local script execution and shell/WebView behavior, and introduce backup and HTTP relay support for the web API and web UI.

New Features:
- Allow editing individual MCP server configurations via a JSON mcpServers config tab in settings.
- Add import flows for Tavern/SillyTavern characters (PNG and JSON), world books, and presets with user feedback in roleplay screens.
- Expose backup status, export, and restore endpoints plus HTTP relay endpoints in the web API, with corresponding TypeScript types and client helpers in the web UI.

Enhancements:
- Tighten JavaScript and Python local tool execution with size limits, timeouts, bounded logging, and more robust process handling.
- Improve code block execution and preview handling, including normalized language detection and safer WebView configuration and navigation interception.
- Refine embedded shell input focus and soft keyboard control for a smoother terminal experience.
- Optimize markdown preview HTML loading by caching the template in memory.

Tests:
- Add sample-based Tavern import tests for characters, world info, and presets to validate decoding against real-world files.