### PR TITLE
Fix skill package imports and cursor window state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.eterultimate.eteruee"
         minSdk = 26
         targetSdk = 37
-        versionCode = 170
-        versionName = "5.2.15"
+        versionCode = 171
+        versionName = "5.2.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
@@ -51,7 +51,7 @@ fun createSkillTools(
                             put("type", "string")
                             put(
                                 "description",
-                                "Optional relative path to a file inside the skill directory. Omit to read the default SKILL.md instructions. Only use paths extracted from Markdown links in the SKILL.md content. Do NOT guess or infer paths."
+                                "Optional relative path to a file in the skill package. Omit to read the default SKILL.md instructions. Only use paths extracted from Markdown links in the SKILL.md content. Do NOT guess or infer paths."
                             )
                         })
                     },
@@ -70,7 +70,7 @@ fun createSkillTools(
                         ?: error("Skill '$name' not found")
                 } else {
                     val target = skillManager.resolveSkillFile(name, path)
-                        ?: error("Path '$path' is outside the skill directory")
+                        ?: error("Path '$path' is outside the skill package")
                     require(target.exists()) { "File '$path' not found in skill '$name'" }
                     target.readText()
                 }

--- a/app/src/main/java/com/eterultimate/eteruee/data/files/SkillManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/files/SkillManager.kt
@@ -1,8 +1,11 @@
 ﻿package com.eterultimate.eteruee.data.files
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import java.io.File
+import java.util.LinkedHashMap
+import java.util.zip.ZipInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.eterultimate.eteruee.data.datastore.SettingsStore
@@ -23,14 +26,11 @@ class SkillManager(
 
     fun listSkills(): List<SkillMetadata> {
         val skillsDir = getSkillsDir()
-        return skillsDir.listFiles()
-            ?.filter { it.isDirectory }
-            ?.mapNotNull { dir ->
-                val skillFile = dir.resolve("SKILL.md")
-                if (!skillFile.exists()) return@mapNotNull null
-                parseSkillFile(skillFile, dir)
+        return findSkillFiles(skillsDir)
+            .mapNotNull { skillFile ->
+                parseSkillFile(skillFile, skillFile.parentFile ?: return@mapNotNull null)
             }
-            ?: emptyList()
+            .distinctBy { it.name }
     }
 
     fun readSkillBody(skillName: String): String? {
@@ -83,6 +83,13 @@ class SkillManager(
     }
 
     fun saveSkillFilesAtomically(skillName: String, files: Map<String, String>): Boolean {
+        return saveSkillBinaryFilesAtomically(
+            skillName = skillName,
+            files = files.mapValues { it.value.toByteArray() }
+        )
+    }
+
+    private fun saveSkillBinaryFilesAtomically(skillName: String, files: Map<String, ByteArray>): Boolean {
         val skillsDir = getSkillsDir()
         val targetDir = resolveSkillDir(skillName) ?: return false
         val stagingDir = createTempSkillDir(skillsDir, skillName, "staging") ?: return false
@@ -92,13 +99,14 @@ class SkillManager(
             for ((relativePath, content) in files) {
                 val target = SkillPaths.resolveSkillFile(stagingDir, relativePath) ?: return false
                 target.parentFile?.mkdirs()
-                target.writeText(content)
+                target.writeBytes(content)
             }
 
             if (!stagingDir.resolve("SKILL.md").exists()) return false
 
             if (targetDir.exists()) {
                 backupDir = createTempSkillDir(skillsDir, skillName, "backup") ?: return false
+                backupDir.delete()
                 if (!targetDir.renameTo(backupDir)) return false
             }
 
@@ -127,6 +135,93 @@ class SkillManager(
         }
     }
 
+    fun saveSkillPackageFiles(packageName: String, files: Map<String, ByteArray>): List<SkillMetadata>? {
+        if (files.isEmpty()) return null
+        val skillsDir = getSkillsDir()
+        val targetRoot = resolvePackageDir(skillsDir, packageName) ?: return null
+        val stagingRoot = createTempSkillDir(skillsDir, sanitizePackageName(packageName), "package-staging")
+            ?: return null
+        var backupRoot: File? = null
+
+        try {
+            for ((relativePath, content) in files) {
+                val target = SkillPaths.resolveSkillPackageFile(stagingRoot, relativePath) ?: return null
+                target.parentFile?.mkdirs()
+                target.writeBytes(content)
+            }
+
+            val importedSkills = files.keys
+                .filter { it.substringAfterLast('/') == "SKILL.md" }
+                .mapNotNull { relativePath ->
+                    val skillFile = SkillPaths.resolveSkillPackageFile(stagingRoot, relativePath)
+                        ?: return@mapNotNull null
+                    parseSkillFile(skillFile, skillFile.parentFile ?: return@mapNotNull null)
+                }
+                .distinctBy { it.name }
+
+            if (importedSkills.isEmpty()) return null
+
+            if (targetRoot.exists()) {
+                backupRoot = createTempSkillDir(skillsDir, targetRoot.name, "package-backup") ?: return null
+                backupRoot.delete()
+                if (!targetRoot.renameTo(backupRoot)) return null
+            }
+
+            if (!stagingRoot.renameTo(targetRoot)) {
+                if (backupRoot != null && !targetRoot.exists()) {
+                    backupRoot.renameTo(targetRoot)
+                }
+                return null
+            }
+
+            backupRoot?.deleteRecursively()
+            return files.keys
+                .filter { it.substringAfterLast('/') == "SKILL.md" }
+                .mapNotNull { relativePath ->
+                    val skillFile = SkillPaths.resolveSkillPackageFile(targetRoot, relativePath)
+                        ?: return@mapNotNull null
+                    parseSkillFile(skillFile, skillFile.parentFile ?: return@mapNotNull null)
+                }
+                .distinctBy { it.name }
+                .takeIf { it.isNotEmpty() }
+        } catch (e: Exception) {
+            Log.w(TAG, "saveSkillPackageFiles: Failed to save package $packageName", e)
+            if (backupRoot != null && !targetRoot.exists()) {
+                backupRoot.renameTo(targetRoot)
+            }
+            return null
+        } finally {
+            if (stagingRoot.exists()) {
+                stagingRoot.deleteRecursively()
+            }
+            if (backupRoot?.exists() == true && targetRoot.exists()) {
+                backupRoot.deleteRecursively()
+            }
+        }
+    }
+
+    fun importSkillZip(uri: Uri): List<SkillMetadata>? {
+        val displayName = FileUtils.getFileNameFromUri(context, uri)
+            ?: uri.lastPathSegment
+            ?: "skill-package.zip"
+        val zipFiles = readSkillZipFiles(uri)
+        val files = stripCommonRoot(zipFiles)
+        val skillMdEntries = files.keys.filter { it.substringAfterLast('/') == "SKILL.md" }
+        if (skillMdEntries.isEmpty()) return null
+
+        val rootSkillFile = skillMdEntries.singleOrNull { it == "SKILL.md" }
+        if (skillMdEntries.size == 1 && rootSkillFile != null) {
+            val skillMdContent = String(files[rootSkillFile] ?: return null, Charsets.UTF_8)
+            val skillName = SkillFrontmatterParser.parse(skillMdContent)["name"] ?: return null
+            if (skillName.isBlank()) return null
+            if (!saveSkillBinaryFilesAtomically(skillName, files)) return null
+            val skillDir = resolveSkillDir(skillName) ?: return null
+            return listOfNotNull(parseSkillFile(skillDir.resolve("SKILL.md"), skillDir))
+        }
+
+        return saveSkillPackageFiles(displayName, files)
+    }
+
     fun deleteSkillFile(skillName: String, relativePath: String): Boolean {
         val skillDir = resolveSkillDir(skillName) ?: return false
         val target = SkillPaths.resolveSkillFile(skillDir, relativePath) ?: return false
@@ -135,11 +230,19 @@ class SkillManager(
 
     fun resolveSkillFile(skillName: String, relativePath: String): File? {
         val skillDir = resolveSkillDir(skillName) ?: return null
-        return SkillPaths.resolveSkillFile(skillDir, relativePath)
+        val skillsRoot = getSkillsDir().canonicalFile
+        val packageRoot = skillDir.parentFile ?: return null
+        if (packageRoot.canonicalFile == skillsRoot) {
+            return SkillPaths.resolveSkillFile(skillDir, relativePath)
+        }
+        return SkillPaths.resolveSkillPackageFile(packageRoot, skillDir.name + File.separator + relativePath)
     }
 
     private fun resolveSkillDir(skillName: String): File? {
-        return SkillPaths.resolveSkillDir(getSkillsDir(), skillName)
+        val directDir = SkillPaths.resolveSkillDir(getSkillsDir(), skillName)
+        if (directDir?.resolve("SKILL.md")?.exists() == true) return directDir
+
+        return listSkills().firstOrNull { it.name == skillName }?.skillDir ?: directDir
     }
 
     private fun createTempSkillDir(skillsRoot: File, skillName: String, suffix: String): File? {
@@ -150,6 +253,64 @@ class SkillManager(
             }
         }
         return null
+    }
+
+    private fun resolvePackageDir(skillsRoot: File, packageName: String): File? {
+        val baseName = sanitizePackageName(packageName)
+        val direct = SkillPaths.resolveSkillDir(skillsRoot, baseName) ?: return null
+        if (!direct.resolve("SKILL.md").exists()) return direct
+
+        repeat(100) { attempt ->
+            val candidate = SkillPaths.resolveSkillDir(skillsRoot, "$baseName-package-$attempt")
+                ?: return@repeat
+            if (!candidate.exists() || !candidate.resolve("SKILL.md").exists()) return candidate
+        }
+        return null
+    }
+
+    private fun sanitizePackageName(name: String): String {
+        val sanitized = name
+            .substringBeforeLast('.', missingDelimiterValue = name)
+            .replace(Regex("""[^A-Za-z0-9._-]"""), "-")
+            .trim('-', '.', '_')
+        return sanitized.takeIf { it.isNotBlank() && it != "." && it != ".." } ?: "skill-package"
+    }
+
+    private fun readSkillZipFiles(uri: Uri): Map<String, ByteArray> {
+        val files = LinkedHashMap<String, ByteArray>()
+        val input = context.contentResolver.openInputStream(uri) ?: return emptyMap()
+        ZipInputStream(input).use { zipIn ->
+            while (true) {
+                val entry = zipIn.nextEntry ?: break
+                if (!entry.isDirectory) {
+                    val relativePath = normalizeZipEntryPath(entry.name) ?: return emptyMap()
+                    files[relativePath] = zipIn.readBytes()
+                }
+                zipIn.closeEntry()
+            }
+        }
+        return files
+    }
+
+    private fun normalizeZipEntryPath(entryName: String): String? {
+        val normalized = entryName.replace('\\', '/').trimStart('/')
+        if (normalized.isBlank()) return null
+        val segments = normalized.split('/').filter { it.isNotBlank() }
+        if (segments.any { it == "." || it == ".." }) return null
+        return segments.joinToString("/")
+    }
+
+    private fun stripCommonRoot(files: Map<String, ByteArray>): Map<String, ByteArray> {
+        if (files.isEmpty()) return files
+        val roots = files.keys.map { it.substringBefore('/') }.distinct()
+        if (roots.size != 1) return files
+
+        val root = roots.single()
+        if (files.keys.any { it == root }) return files
+
+        return files.mapKeysTo(LinkedHashMap()) { (path, _) ->
+            path.removePrefix("$root/")
+        }.filterKeys { it.isNotBlank() }
     }
 
     private fun parseSkillFile(skillFile: File, skillDir: File): SkillMetadata? {
@@ -169,6 +330,23 @@ class SkillManager(
             Log.w(TAG, "parseSkillFile: Failed to parse ${skillFile.absolutePath}", it)
             null
         }
+    }
+
+    private fun findSkillFiles(root: File): List<File> {
+        val result = mutableListOf<File>()
+        fun visit(dir: File) {
+            if (dir.name.startsWith(".")) return
+            val skillFile = dir.resolve("SKILL.md")
+            if (skillFile.isFile) {
+                result += skillFile
+            }
+            dir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.sortedBy { it.name }
+                ?.forEach(::visit)
+        }
+        visit(root)
+        return result.sortedBy { it.relativeTo(root).path }
     }
 }
 

--- a/app/src/main/java/com/eterultimate/eteruee/data/files/SkillPaths.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/files/SkillPaths.kt
@@ -27,6 +27,15 @@ internal object SkillPaths {
         return canonicalTarget.takeIf { it.isSameOrInside(canonicalSkillDir) }
     }
 
+    fun resolveSkillPackageFile(packageRoot: File, relativePath: String): File? {
+        if (relativePath.isBlank()) return null
+
+        val canonicalPackageRoot = packageRoot.canonicalFile
+        val canonicalTarget = canonicalPackageRoot.resolve(relativePath).canonicalFile
+
+        return canonicalTarget.takeIf { it.isSameOrInside(canonicalPackageRoot) }
+    }
+
     private fun File.isSameOrInside(root: File): Boolean {
         val rootPath = root.canonicalFile.path
         val currentPath = canonicalFile.path

--- a/app/src/main/java/com/eterultimate/eteruee/data/repository/ConversationRepository.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/repository/ConversationRepository.kt
@@ -344,6 +344,10 @@ class ConversationRepository(
                     e.printStackTrace()
                     offset += pageSize
                     continue
+                } catch (e: IllegalStateException) {
+                    e.printStackTrace()
+                    offset += pageSize
+                    continue
                 }
                 if (page.isEmpty()) break
                 page.forEach { entity ->

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/extensions/SkillsPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/extensions/SkillsPage.kt
@@ -1,5 +1,7 @@
 package com.eterultimate.eteruee.ui.pages.extensions
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,6 +50,7 @@ import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Add01
 import me.rerere.hugeicons.stroke.Delete01
 import me.rerere.hugeicons.stroke.Download01
+import me.rerere.hugeicons.stroke.FileZip
 import me.rerere.hugeicons.stroke.MoreVertical
 import me.rerere.hugeicons.stroke.Puzzle
 import com.eterultimate.eteruee.data.files.SkillFrontmatterParser
@@ -71,7 +74,22 @@ fun SkillsPage() {
     val context = LocalContext.current
     var showAddDialog by rememberSaveable { mutableStateOf(false) }
     var showImportDialog by rememberSaveable { mutableStateOf(false) }
+    var isZipImporting by remember { mutableStateOf(false) }
     var deleteTarget by remember { mutableStateOf<SkillMetadata?>(null) }
+    val zipImportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        isZipImporting = true
+        vm.importSkillZip(uri) { success, message ->
+            isZipImporting = false
+            if (success) {
+                toaster.show(context.getString(R.string.skills_page_import_success, message))
+            } else {
+                toaster.show(context.getString(R.string.skills_page_import_failed, message))
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -92,6 +110,22 @@ fun SkillsPage() {
                         HugeIcons.Download01,
                         contentDescription = stringResource(R.string.skills_page_import_from_github)
                     )
+                }
+                SmallFloatingActionButton(
+                    onClick = {
+                        if (!isZipImporting) {
+                            zipImportLauncher.launch(arrayOf("application/zip", "application/octet-stream"))
+                        }
+                    }
+                ) {
+                    if (isZipImporting) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(
+                            HugeIcons.FileZip,
+                            contentDescription = stringResource(R.string.skills_page_import_from_zip)
+                        )
+                    }
                 }
                 FloatingActionButton(onClick = { showAddDialog = true }) {
                     Icon(HugeIcons.Add01, contentDescription = null)

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/extensions/SkillsVM.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/extensions/SkillsVM.kt
@@ -1,5 +1,6 @@
 package com.eterultimate.eteruee.ui.pages.extensions
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -66,20 +67,10 @@ class SkillsVM(
                     return@launch
                 }
 
-                val skillMdEntry = files.find { it.first == "SKILL.md" } ?: run {
+                val skillMdEntries = files.filter { it.first.substringAfterLast('/') == "SKILL.md" }
+                val skillMdEntry = skillMdEntries.find { it.first == "SKILL.md" }
+                if (skillMdEntries.isEmpty()) {
                     withContext(Dispatchers.Main) { onResult(false, "目录中未找到 SKILL.md") }
-                    return@launch
-                }
-
-                val skillMdContent = downloadText(skillMdEntry.second) ?: run {
-                    withContext(Dispatchers.Main) { onResult(false, "下载 SKILL.md 失败，请检查链接或网络") }
-                    return@launch
-                }
-
-                val frontmatter = SkillFrontmatterParser.parse(skillMdContent)
-                val name = frontmatter["name"]
-                if (name.isNullOrBlank()) {
-                    withContext(Dispatchers.Main) { onResult(false, "SKILL.md 格式错误：缺少 name 字段") }
                     return@launch
                 }
 
@@ -93,14 +84,59 @@ class SkillsVM(
                     fileContents[relativePath] = content
                 }
 
-                val saved = skillManager.saveSkillFilesAtomically(name, fileContents)
-                if (!saved) {
-                    withContext(Dispatchers.Main) { onResult(false, "保存失败") }
+                val importedNames = if (skillMdEntries.size == 1 && skillMdEntry != null) {
+                    val skillMdContent = fileContents[skillMdEntry.first] ?: run {
+                        withContext(Dispatchers.Main) { onResult(false, "下载 SKILL.md 失败，请检查链接或网络") }
+                        return@launch
+                    }
+
+                    val frontmatter = SkillFrontmatterParser.parse(skillMdContent)
+                    val name = frontmatter["name"]
+                    if (name.isNullOrBlank()) {
+                        withContext(Dispatchers.Main) { onResult(false, "SKILL.md 格式错误：缺少 name 字段") }
+                        return@launch
+                    }
+
+                    val saved = skillManager.saveSkillFilesAtomically(name, fileContents)
+                    if (!saved) {
+                        withContext(Dispatchers.Main) { onResult(false, "保存失败") }
+                        return@launch
+                    }
+                    listOf(name)
+                } else {
+                    val packageName = info.path.substringAfterLast('/').ifBlank { info.repo }
+                    val imported = skillManager.saveSkillPackageFiles(
+                        packageName = packageName,
+                        files = fileContents.mapValues { it.value.toByteArray() }
+                    )
+                    if (imported.isNullOrEmpty()) {
+                        withContext(Dispatchers.Main) { onResult(false, "保存失败") }
+                        return@launch
+                    }
+                    imported.map { it.name }
+                }
+
+                _skills.value = skillManager.listSkills()
+                withContext(Dispatchers.Main) { onResult(true, importedNames.joinToString(", ")) }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) { onResult(false, e.message ?: "未知错误") }
+            }
+        }
+    }
+
+    fun importSkillZip(uri: Uri, onResult: (Boolean, String) -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val imported = skillManager.importSkillZip(uri)
+                if (imported.isNullOrEmpty()) {
+                    withContext(Dispatchers.Main) { onResult(false, "ZIP 中未找到有效的 SKILL.md") }
                     return@launch
                 }
 
                 _skills.value = skillManager.listSkills()
-                withContext(Dispatchers.Main) { onResult(true, name) }
+                withContext(Dispatchers.Main) {
+                    onResult(true, imported.joinToString(", ") { it.name })
+                }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) { onResult(false, e.message ?: "未知错误") }
             }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1002,6 +1002,7 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="skills_page_import_description">GitHubリポジトリのURLを入力すると、ルートディレクトリのSKILL.mdファイルが自動的にダウンロードされます。</string>
   <string name="skills_page_import_failed">インポートに失敗しました: %s</string>
   <string name="skills_page_import_from_github">GitHubからインポート</string>
+  <string name="skills_page_import_from_zip">ZIPパッケージをインポート</string>
   <string name="skills_page_import_success">スキルをインポートしました: %s</string>
   <string name="skills_page_more_actions">その他のアクション</string>
   <string name="skills_page_name_error">名前フィールドが見つかりません。フロントマター形式を確認してください</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1002,6 +1002,7 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="skills_page_import_description">GitHub 저장소 URL을 입력하면 루트 디렉터리의 SKILL.md 파일이 자동으로 다운로드됩니다.</string>
   <string name="skills_page_import_failed">가져오기 실패: %s</string>
   <string name="skills_page_import_from_github">GitHub에서 가져오기</string>
+  <string name="skills_page_import_from_zip">ZIP 패키지 가져오기</string>
   <string name="skills_page_import_success">스킬 가져오기 완료: %s</string>
   <string name="skills_page_more_actions">더 많은 작업</string>
   <string name="skills_page_name_error">이름 필드를 찾을 수 없습니다. 프론트매터 형식을 확인하세요.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1002,6 +1002,7 @@
   <string name="skills_page_import_description">Введите URL репозитория GitHub, и файл SKILL.md в корневом каталоге будет загружен автоматически.</string>
   <string name="skills_page_import_failed">Не удалось импортировать: %s</string>
   <string name="skills_page_import_from_github">Импорт из GitHub</string>
+  <string name="skills_page_import_from_zip">Импорт ZIP-пакета</string>
   <string name="skills_page_import_success">Навык импортирован: %s</string>
   <string name="skills_page_more_actions">Дополнительные действия</string>
   <string name="skills_page_name_error">Не удаётся найти поле name, проверьте формат frontmatter</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1009,6 +1009,7 @@
   <string name="skills_page_import_description">輸入 GitHub 儲存庫網址，系統將自動下載根目錄中的 SKILL.md 檔案。</string>
   <string name="skills_page_import_failed">匯入失敗：%s</string>
   <string name="skills_page_import_from_github">從 GitHub 匯入</string>
+  <string name="skills_page_import_from_zip">匯入 ZIP 套件</string>
   <string name="skills_page_import_success">已匯入技能：%s</string>
   <string name="skills_page_more_actions">更多操作</string>
   <string name="skills_page_name_error">找不到名稱欄位，請檢查 frontmatter 格式</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1018,6 +1018,7 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="skills_page_import_description">输入 GitHub 仓库 URL，将自动下载根目录中的 SKILL.md 文件。</string>
   <string name="skills_page_import_failed">导入失败：%s</string>
   <string name="skills_page_import_from_github">从 GitHub 导入</string>
+  <string name="skills_page_import_from_zip">导入 ZIP 包</string>
   <string name="skills_page_import_success">技能已导入：%s</string>
   <string name="skills_page_more_actions">更多操作</string>
   <string name="skills_page_name_error">找不到名称字段，请检查 frontmatter 格式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1016,6 +1016,7 @@
   <string name="skills_page_import_description">Enter a GitHub repository URL, and the SKILL.md file in the root directory will be downloaded automatically.</string>
   <string name="skills_page_import_failed">Import failed: %s</string>
   <string name="skills_page_import_from_github">Import from GitHub</string>
+  <string name="skills_page_import_from_zip">Import ZIP package</string>
   <string name="skills_page_import_success">Skill imported: %s</string>
   <string name="skills_page_more_actions">More actions</string>
   <string name="skills_page_name_error">Cannot find the name field, please check the frontmatter format</string>


### PR DESCRIPTION
## Summary
- Preserve package-relative structure when importing ZIP/GitHub skill packages with multiple `SKILL.md` files.
- Add local ZIP import entry point on the Skills page.
- Allow package skills to resolve shared files from the package root while keeping path traversal constrained.
- Includes the prior cursor window state fix already on this branch.

## Verification
- `GRADLE_USER_HOME=.gradle ./gradlew.bat :app:compileDebugKotlin --no-daemon`
- `git diff --check`