### PR TITLE
[codex] Optimize startup temp cleanup with native runtime

### DIFF
--- a/app/src/main/cpp/native_runtime.cpp
+++ b/app/src/main/cpp/native_runtime.cpp
@@ -52,6 +52,45 @@ int deleteTree(const char* path) {
     return 0;
 }
 
+int ensureDirectory(const char* path) {
+    if (mkdir(path, 0700) == 0) return 0;
+    return errno == EEXIST ? 0 : errno;
+}
+
+int clearDirectory(const char* path) {
+    struct stat info {};
+    if (lstat(path, &info) != 0) {
+        return errno == ENOENT ? ensureDirectory(path) : errno;
+    }
+
+    if (!S_ISDIR(info.st_mode) || S_ISLNK(info.st_mode)) {
+        const int deleteResult = deleteTree(path);
+        return deleteResult == 0 ? ensureDirectory(path) : deleteResult;
+    }
+
+    DIR* dir = opendir(path);
+    if (dir == nullptr) return errno;
+
+    int firstError = 0;
+    while (dirent* entry = readdir(dir)) {
+        const char* name = entry->d_name;
+        if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'))) {
+            continue;
+        }
+
+        std::string child(path);
+        child.push_back('/');
+        child.append(name);
+
+        const int childResult = deleteTree(child.c_str());
+        if (childResult != 0 && firstError == 0) {
+            firstError = childResult;
+        }
+    }
+    closedir(dir);
+    return firstError;
+}
+
 bool isTcpPortAvailable(const int port) {
     if (port < 1 || port > 65535) return false;
 
@@ -82,6 +121,22 @@ Java_com_eterultimate_eteruee_runtime_NativeRuntime_nativeDeleteTree(
     if (chars == nullptr) return ENOMEM;
 
     const int result = deleteTree(chars);
+    env->ReleaseStringUTFChars(path, chars);
+    return result;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_eterultimate_eteruee_runtime_NativeRuntime_nativeClearDirectory(
+    JNIEnv* env,
+    jobject /* thiz */,
+    jstring path
+) {
+    if (path == nullptr) return EINVAL;
+
+    const char* chars = env->GetStringUTFChars(path, nullptr);
+    if (chars == nullptr) return ENOMEM;
+
+    const int result = clearDirectory(chars);
     env->ReleaseStringUTFChars(path, chars);
     return result;
 }

--- a/app/src/main/java/com/eterultimate/eteruee/EterUeeApp.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/EterUeeApp.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import com.eterultimate.eteruee.common.android.appTempFolder
 import com.eterultimate.eteruee.di.appModule
 import com.eterultimate.eteruee.di.dataSourceModule
 import com.eterultimate.eteruee.di.repositoryModule
@@ -39,6 +38,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.workmanager.koin.workManagerFactory
 import org.koin.core.context.startKoin
+import java.io.File
 
 private const val TAG = "EterUeeApp"
 private const val DEFERRED_STARTUP_DELAY_MS = 1_500L
@@ -112,10 +112,7 @@ class EterUeeApp : Application() {
 
     private fun deleteTempFiles() {
         runCatching {
-            val dir = appTempFolder
-            if (dir.exists()) {
-                NativeRuntime.deleteDirectoryTree(dir)
-            }
+            NativeRuntime.clearDirectory(File(cacheDir, "temp"))
         }.onFailure {
             Log.e(TAG, "deleteTempFiles failed", it)
         }

--- a/app/src/main/java/com/eterultimate/eteruee/runtime/NativeRuntime.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/runtime/NativeRuntime.kt
@@ -11,6 +11,8 @@ object NativeRuntime {
 
     private external fun nativeDeleteTree(path: String): Int
 
+    private external fun nativeClearDirectory(path: String): Int
+
     private external fun nativeIsTcpPortAvailable(port: Int): Boolean
 
     fun deleteDirectoryTree(directory: File): Boolean {
@@ -22,6 +24,16 @@ object NativeRuntime {
         }.getOrDefault(false)
 
         return nativeDeleted || directory.deleteRecursively()
+    }
+
+    fun clearDirectory(directory: File): Boolean {
+        if (nativeLoaded) {
+            val nativeCleared = runCatching {
+                nativeClearDirectory(directory.absolutePath) == 0 && directory.isDirectory
+            }.getOrDefault(false)
+            if (nativeCleared) return true
+        }
+        return clearDirectoryJvm(directory)
     }
 
     fun isTcpPortAvailable(port: Int): Boolean {
@@ -41,6 +53,19 @@ object NativeRuntime {
         } catch (_: Exception) {
             false
         }
+    }
+
+    private fun clearDirectoryJvm(directory: File): Boolean {
+        if (directory.exists() && !directory.isDirectory) {
+            if (!directory.delete()) return false
+        }
+        if (!directory.exists() && !directory.mkdirs()) return false
+
+        var success = true
+        directory.listFiles()?.forEach { child ->
+            success = child.deleteRecursively() && success
+        }
+        return success && directory.isDirectory
     }
 
     private fun isAndroidRuntime(): Boolean {

--- a/app/src/main/java/com/eterultimate/eteruee/runtime/NativeRuntime.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/runtime/NativeRuntime.kt
@@ -2,6 +2,7 @@ package com.eterultimate.eteruee.runtime
 
 import java.io.File
 import java.net.ServerSocket
+import java.nio.file.Files
 
 object NativeRuntime {
     private val nativeLoaded: Boolean = isAndroidRuntime() && runCatching {
@@ -29,7 +30,7 @@ object NativeRuntime {
     fun clearDirectory(directory: File): Boolean {
         if (nativeLoaded) {
             val nativeCleared = runCatching {
-                nativeClearDirectory(directory.absolutePath) == 0 && directory.isDirectory
+                nativeClearDirectory(directory.absolutePath) == 0
             }.getOrDefault(false)
             if (nativeCleared) return true
         }
@@ -56,16 +57,18 @@ object NativeRuntime {
     }
 
     private fun clearDirectoryJvm(directory: File): Boolean {
-        if (directory.exists() && !directory.isDirectory) {
+        val isSymlink = Files.isSymbolicLink(directory.toPath())
+        if (isSymlink || (directory.exists() && !directory.isDirectory)) {
             if (!directory.delete()) return false
         }
         if (!directory.exists() && !directory.mkdirs()) return false
 
+        val children = directory.listFiles() ?: return false
         var success = true
-        directory.listFiles()?.forEach { child ->
+        children.forEach { child ->
             success = child.deleteRecursively() && success
         }
-        return success && directory.isDirectory
+        return success
     }
 
     private fun isAndroidRuntime(): Boolean {

--- a/app/src/test/java/com/eterultimate/eteruee/runtime/NativeRuntimeTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/runtime/NativeRuntimeTest.kt
@@ -19,6 +19,28 @@ class NativeRuntimeTest {
     }
 
     @Test
+    fun clearDirectoryRemovesNestedFilesAndKeepsRoot() {
+        val root = Files.createTempDirectory("eteruee-native-runtime-").toFile()
+        val nested = File(root, "a/b/c").apply { mkdirs() }
+        File(nested, "payload.txt").writeText("payload")
+
+        assertTrue(NativeRuntime.clearDirectory(root))
+        assertTrue(root.isDirectory)
+        assertFalse(File(root, "a").exists())
+    }
+
+    @Test
+    fun clearDirectoryCreatesMissingRoot() {
+        val parent = Files.createTempDirectory("eteruee-native-runtime-").toFile()
+        val root = File(parent, "missing-temp")
+
+        assertTrue(NativeRuntime.clearDirectory(root))
+        assertTrue(root.isDirectory)
+
+        parent.deleteRecursively()
+    }
+
+    @Test
     fun isTcpPortAvailableReflectsBoundPort() {
         val server = ServerSocket(0)
         val port = server.localPort

--- a/app/src/test/java/com/eterultimate/eteruee/runtime/NativeRuntimeTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/runtime/NativeRuntimeTest.kt
@@ -3,6 +3,7 @@ package com.eterultimate.eteruee.runtime
 import java.io.File
 import java.net.ServerSocket
 import java.nio.file.Files
+import org.junit.Assume.assumeNoException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -38,6 +39,27 @@ class NativeRuntimeTest {
         assertTrue(root.isDirectory)
 
         parent.deleteRecursively()
+    }
+
+    @Test
+    fun clearDirectoryDeletesSymlinkWithoutClearingTarget() {
+        val parent = Files.createTempDirectory("eteruee-native-runtime-")
+        val target = Files.createDirectory(parent.resolve("target"))
+        Files.writeString(target.resolve("payload.txt"), "payload")
+        val link = parent.resolve("temp-link")
+
+        try {
+            Files.createSymbolicLink(link, target)
+        } catch (e: Exception) {
+            assumeNoException(e)
+        }
+
+        assertTrue(NativeRuntime.clearDirectory(link.toFile()))
+        assertTrue(Files.isDirectory(link))
+        assertFalse(Files.isSymbolicLink(link))
+        assertTrue(Files.exists(target.resolve("payload.txt")))
+
+        parent.toFile().deleteRecursively()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `NativeRuntime.clearDirectory()` backed by C++ for clearing app temp files while preserving the temp root directory.
- Use it from the deferred startup cleanup task so the app avoids Kotlin recursive file deletion work after launch.
- Keep a JVM fallback path and unit coverage for non-Android test runs.

## Validation

- `./gradlew.bat :app:externalNativeBuildDebug :app:compileDebugKotlin :app:testDebugUnitTest --tests "com.eterultimate.eteruee.runtime.NativeRuntimeTest"`