### PR TITLE
Fix truncated chat streaming and regeneration loading

### DIFF
--- a/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -186,7 +186,6 @@ class ChatCompletionsAPI(
                                     ?: throw Exception("delta/message is null")
                                 val finishReason =
                                     choice["finish_reason"]?.jsonPrimitive?.contentOrNull
-                                        ?: "unknown"
                                 add(
                                     UIMessageChoice(
                                         index = 0,

--- a/ai/src/main/java/com/eterultimate/eteruee/ai/sdk/DefaultAISDK.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/sdk/DefaultAISDK.kt
@@ -100,7 +100,7 @@ class DefaultAISDK(
                 emit(chunk)
             }
         }
-            .map { chunk -> convertMessageChunkToTextChunk(chunk) }
+            .map { chunk -> chunk.toTextChunk() }
             .catch { e ->
                 Log.e(TAG, "streamText error", e)
                 throw AISDKException("Stream failed: ${e.message}", e)
@@ -113,46 +113,47 @@ class DefaultAISDK(
         throw UnsupportedOperationException("generateObject is not yet implemented")
     }
 
-    /**
-     * 将 MessageChunk 转换为 TextChunk
-     */
-    private fun convertMessageChunkToTextChunk(chunk: MessageChunk): TextChunk {
-        // 检查是否有 usage 信息
-        chunk.usage?.let {
-            return TextChunk.Usage(it)
-        }
+}
 
-        // 检查是否有 finish reason
-        if (chunk.choices.any { it.finishReason != null }) {
-            return TextChunk.Finish
-        }
-
-        // 提取文本增量
-        val textDeltas = chunk.choices.flatMap { choice ->
-            choice.delta?.parts?.filterIsInstance<com.eterultimate.eteruee.ai.ui.UIMessagePart.Text>() ?: emptyList()
-        }
-
-        if (textDeltas.isNotEmpty()) {
-            return TextChunk.TextDelta(textDeltas.joinToString("") { it.text })
-        }
-
-        // 提取工具调用
-        val toolCalls = chunk.choices.flatMap { choice ->
-            choice.delta?.parts?.filterIsInstance<com.eterultimate.eteruee.ai.ui.UIMessagePart.Tool>() ?: emptyList()
-        }
-
-        if (toolCalls.isNotEmpty()) {
-            val toolCall = toolCalls.first()
-            return TextChunk.ToolCall(
-                toolCallId = toolCall.toolCallId,
-                toolName = toolCall.toolName,
-                arguments = toolCall.input
-            )
-        }
-
-        // 如果没有内容,返回空文本块
-        return TextChunk.TextDelta("")
+/**
+ * 将 MessageChunk 转换为 TextChunk
+ */
+internal fun MessageChunk.toTextChunk(): TextChunk {
+    // 检查是否有 usage 信息
+    usage?.let {
+        return TextChunk.Usage(it)
     }
+
+    // 检查是否有 finish reason
+    if (choices.any { it.finishReason != null }) {
+        return TextChunk.Finish
+    }
+
+    // 提取文本增量
+    val textDeltas = choices.flatMap { choice ->
+        choice.delta?.parts?.filterIsInstance<com.eterultimate.eteruee.ai.ui.UIMessagePart.Text>() ?: emptyList()
+    }
+
+    if (textDeltas.isNotEmpty()) {
+        return TextChunk.TextDelta(textDeltas.joinToString("") { it.text })
+    }
+
+    // 提取工具调用
+    val toolCalls = choices.flatMap { choice ->
+        choice.delta?.parts?.filterIsInstance<com.eterultimate.eteruee.ai.ui.UIMessagePart.Tool>() ?: emptyList()
+    }
+
+    if (toolCalls.isNotEmpty()) {
+        val toolCall = toolCalls.first()
+        return TextChunk.ToolCall(
+            toolCallId = toolCall.toolCallId,
+            toolName = toolCall.toolName,
+            arguments = toolCall.input
+        )
+    }
+
+    // 如果没有内容,返回空文本块
+    return TextChunk.TextDelta("")
 }
 
 /**

--- a/ai/src/test/java/com/eterultimate/eteruee/ai/sdk/DefaultAISDKTest.kt
+++ b/ai/src/test/java/com/eterultimate/eteruee/ai/sdk/DefaultAISDKTest.kt
@@ -1,0 +1,53 @@
+package com.eterultimate.eteruee.ai.sdk
+
+import com.eterultimate.eteruee.ai.core.MessageRole
+import com.eterultimate.eteruee.ai.ui.MessageChunk
+import com.eterultimate.eteruee.ai.ui.UIMessage
+import com.eterultimate.eteruee.ai.ui.UIMessageChoice
+import com.eterultimate.eteruee.ai.ui.UIMessagePart
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefaultAISDKTest {
+    @Test
+    fun `text delta chunk should not be converted to finish`() {
+        val chunk = MessageChunk(
+            id = "chatcmpl-1",
+            model = "test-model",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(UIMessagePart.Text("hello"))
+                    ),
+                    message = null,
+                    finishReason = null
+                )
+            )
+        )
+
+        assertEquals(TextChunk.TextDelta("hello"), chunk.toTextChunk())
+    }
+
+    @Test
+    fun `chunk with finish reason should be converted to finish`() {
+        val chunk = MessageChunk(
+            id = "chatcmpl-1",
+            model = "test-model",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = emptyList()
+                    ),
+                    message = null,
+                    finishReason = "stop"
+                )
+            )
+        )
+
+        assertEquals(TextChunk.Finish, chunk.toTextChunk())
+    }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/di/ViewModelModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/di/ViewModelModule.kt
@@ -31,13 +31,10 @@ val viewModelModule = module {
             settingsStore = get(),
             conversationRepo = get(),
             chatService = get(),
-            aiSDK = get(),
             updateChecker = get(),
             analytics = get(),
             filesManager = get(),
             favoriteRepository = get(),
-            skillManager = get(),
-            localTools = get(),
         )
     }
     viewModelOf(::ChatDrawerVM)

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessage.kt
@@ -90,6 +90,7 @@ import com.eterultimate.eteruee.ui.components.richtext.ZoomableAsyncImage
 import com.eterultimate.eteruee.ui.components.richtext.buildMarkdownPreviewHtml
 import com.eterultimate.eteruee.ui.components.ui.ChainOfThought
 import com.eterultimate.eteruee.ui.components.ui.Favicon
+import com.eterultimate.eteruee.ui.components.ui.RabbitLoadingIndicator
 import com.eterultimate.eteruee.ui.context.LocalNavController
 import com.eterultimate.eteruee.ui.modifier.shimmer
 import com.eterultimate.eteruee.ui.context.LocalSettings
@@ -107,6 +108,7 @@ fun ChatMessage(
     node: MessageNode,
     modifier: Modifier = Modifier,
     loading: Boolean = false,
+    showInlineLoading: Boolean = false,
     model: Model? = null,
     assistant: Assistant? = null,
     lastMessage: Boolean = false,
@@ -187,8 +189,23 @@ fun ChatMessage(
             }
         }
 
-        val showActions = if (lastMessage) {
-            !loading
+        AnimatedVisibility(
+            visible = showInlineLoading && message.role == MessageRole.ASSISTANT,
+            enter = slideInVertically { it / 2 } + fadeIn(),
+            exit = slideOutVertically { it / 2 } + fadeOut()
+        ) {
+            Row(
+                modifier = Modifier.padding(top = 2.dp, start = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RabbitLoadingIndicator(modifier = Modifier.size(28.dp))
+            }
+        }
+
+        val showActions = if (loading) {
+            false
+        } else if (lastMessage) {
+            true
         } else {
             message.parts.isEmptyUIMessage().not()
         }

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatList.kt
@@ -115,6 +115,7 @@ fun ChatList(
     conversation: Conversation,
     state: LazyListState,
     loading: Boolean,
+    loadingNodeId: Uuid? = null,
     processingStatus: String? = null,
     previewMode: Boolean,
     settings: Settings,
@@ -158,6 +159,7 @@ fun ChatList(
                 conversation = conversation,
                 state = state,
                 loading = loading,
+                loadingNodeId = loadingNodeId,
                 processingStatus = processingStatus,
                 settings = settings,
                 hazeState = hazeState,
@@ -188,6 +190,7 @@ private fun ChatListNormal(
     conversation: Conversation,
     state: LazyListState,
     loading: Boolean,
+    loadingNodeId: Uuid? = null,
     processingStatus: String? = null,
     settings: Settings,
     hazeState: HazeState,
@@ -322,7 +325,9 @@ private fun ChatListNormal(
                             node = node,
                             model = node.currentMessage.modelId?.let { settings.findModelById(it) },
                             assistant = settings.getAssistantById(conversation.assistantId),
-                            loading = loading && index == conversation.messageNodes.lastIndex,
+                            loading = loading && (loadingNodeId == node.id ||
+                                (loadingNodeId == null && index == conversation.messageNodes.lastIndex)),
+                            showInlineLoading = loading && loadingNodeId == node.id,
                             onRegenerate = {
                                 onRegenerate(node.currentMessage)
                             },
@@ -368,7 +373,7 @@ private fun ChatListNormal(
                 }
             }
 
-            if (loading) {
+            if (loading && loadingNodeId == null) {
                 item(LoadingIndicatorKey) {
                     Row(
                         modifier = Modifier.padding(8.dp),

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
@@ -85,8 +85,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
 
     val setting by vm.settings.collectAsStateWithLifecycle()
     val conversation by vm.conversation.collectAsStateWithLifecycle()
-    val generationJob by vm.conversationJob.collectAsStateWithLifecycle()
-    val isLoading = generationJob?.isActive == true
+    val isLoading by vm.isLoading.collectAsStateWithLifecycle()
     val regeneratingNodeId = vm.regeneratingNodeId
     val processingStatus by vm.processingStatus.collectAsStateWithLifecycle()
     val currentChatModel by vm.currentChatModel.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
@@ -85,7 +85,9 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
 
     val setting by vm.settings.collectAsStateWithLifecycle()
     val conversation by vm.conversation.collectAsStateWithLifecycle()
-    val isLoading by vm.chatState.isLoading.collectAsStateWithLifecycle()
+    val generationJob by vm.conversationJob.collectAsStateWithLifecycle()
+    val isLoading = generationJob?.isActive == true
+    val regeneratingNodeId = vm.regeneratingNodeId
     val processingStatus by vm.processingStatus.collectAsStateWithLifecycle()
     val currentChatModel by vm.currentChatModel.collectAsStateWithLifecycle()
     val enableWebSearch by vm.enableWebSearch.collectAsStateWithLifecycle()
@@ -106,6 +108,12 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
     LaunchedEffect(drawerState.isOpen) {
         if (drawerState.isOpen) {
             softwareKeyboardController?.hide()
+        }
+    }
+
+    LaunchedEffect(isLoading) {
+        if (!isLoading) {
+            vm.clearRegeneratingNode()
         }
     }
 
@@ -173,6 +181,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                 ChatPageContent(
                     inputState = inputState,
                     isLoading = isLoading,
+                    regeneratingNodeId = regeneratingNodeId,
                     processingStatus = processingStatus,
                     setting = setting,
                     conversation = conversation,
@@ -206,6 +215,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                 ChatPageContent(
                     inputState = inputState,
                     isLoading = isLoading,
+                    regeneratingNodeId = regeneratingNodeId,
                     processingStatus = processingStatus,
                     setting = setting,
                     conversation = conversation,
@@ -233,6 +243,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
 private fun ChatPageContent(
     inputState: ChatInputState,
     isLoading: Boolean,
+    regeneratingNodeId: Uuid?,
     processingStatus: String? = null,
     setting: Settings,
     bigScreen: Boolean,
@@ -370,6 +381,7 @@ private fun ChatPageContent(
                 conversation = conversation,
                 state = chatListState,
                 loading = isLoading,
+                loadingNodeId = regeneratingNodeId,
                 processingStatus = processingStatus,
                 previewMode = previewMode,
                 settings = setting,

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatVM.kt
@@ -73,6 +73,11 @@ class ChatVM(
             .getGenerationJobStateFlow(_conversationId)
             .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
+    val isLoading: StateFlow<Boolean> =
+        conversationJob
+            .map { it?.isActive == true }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
     val processingStatus: StateFlow<String?> =
         chatService
             .getProcessingStatusFlow(_conversationId)
@@ -244,7 +249,7 @@ class ChatVM(
     ) {
         analytics.logEvent("ai_regenerate_at_message", null)
         regeneratingNodeId = if (message.role == com.eterultimate.eteruee.ai.core.MessageRole.ASSISTANT && regenerateAssistantMsg) {
-            conversation.value.getMessageNodeByMessageId(message.id)?.id
+            conversation.value.getMessageNodeByMessage(message)?.id
         } else {
             null
         }

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatVM.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import com.eterultimate.eteruee.ai.provider.Model
-import com.eterultimate.eteruee.ai.sdk.AISDK
 import com.eterultimate.eteruee.ai.ui.UIMessage
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
 import com.eterultimate.eteruee.ai.ui.isEmptyInputMessage
@@ -29,22 +28,17 @@ import com.eterultimate.eteruee.data.datastore.Settings
 import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.data.datastore.getCurrentChatModel
 import com.eterultimate.eteruee.data.files.FilesManager
-import com.eterultimate.eteruee.data.ai.ChatSubagentExecutor
-import com.eterultimate.eteruee.data.ai.ChatToolExecutor
-import com.eterultimate.eteruee.data.files.SkillManager
 import com.eterultimate.eteruee.data.model.Assistant
 import com.eterultimate.eteruee.data.model.Avatar
 import com.eterultimate.eteruee.data.model.Conversation
 import com.eterultimate.eteruee.data.model.MessageNode
 import com.eterultimate.eteruee.data.model.NodeFavoriteTarget
-import com.eterultimate.eteruee.data.model.toMessageNode
 import com.eterultimate.eteruee.data.repository.ConversationRepository
 import com.eterultimate.eteruee.data.repository.FavoriteRepository
 import com.eterultimate.eteruee.service.ChatError
 import com.eterultimate.eteruee.service.ChatService
 import com.eterultimate.eteruee.ui.hooks.writeStringPreference
 import com.eterultimate.eteruee.ui.hooks.ChatInputState
-import com.eterultimate.eteruee.ui.hooks.ChatStateHolder
 import com.eterultimate.eteruee.utils.UiState
 import com.eterultimate.eteruee.utils.UpdateInfo
 import com.eterultimate.eteruee.utils.UpdateChecker
@@ -53,32 +47,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import java.util.Locale
 import kotlin.uuid.Uuid
 
-private const val TAG = "ChatVM"
-
 class ChatVM(
     id: String,
     private val context: Application,
     private val settingsStore: SettingsStore,
     private val conversationRepo: ConversationRepository,
     private val chatService: ChatService,
-    private val aiSDK: AISDK,
     val updateChecker: UpdateChecker,
     private val analytics: FirebaseAnalytics,
     private val filesManager: FilesManager,
     private val favoriteRepository: FavoriteRepository,
-    private val skillManager: SkillManager,
-    private val localTools: com.eterultimate.eteruee.data.ai.tools.LocalTools,
 ) : ViewModel() {
     private val _conversationId: Uuid = Uuid.parse(id)
     val conversation: StateFlow<Conversation> = chatService.getConversationFlow(_conversationId)
     var chatListInitialized by mutableStateOf(false) // 聊天列表是否已经滚动到底部
-
-    // AI SDK 状态持有者
-    val chatState = ChatStateHolder(
-        conversationId = _conversationId,
-        aiSDK = aiSDK,
-        scope = viewModelScope
-    )
+    var regeneratingNodeId by mutableStateOf<Uuid?>(null)
+        private set
 
     // 聊天输入状态 - 保存在 ViewModel 中避免 TransactionTooLargeException
     val inputState = ChatInputState()
@@ -104,59 +88,18 @@ class ChatVM(
     // MCP管理器
     val mcpManager = chatService.mcpManager
 
-    // Subagent 支持
-    private var chatSubagentExecutor: ChatSubagentExecutor? = null
-
     // Subagent 启用状态（可从设置中控制）
     val enableSubagent = settings.map {
         it.enableSubagent
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {
-        // 配置工具执行器
-        chatState.toolExecutor = ChatToolExecutor(
-            settings = settings.value,
-            mcpManager = mcpManager,
-            localTools = localTools,
-            skillManager = skillManager
-        )
-
-        // 配置 Subagent 执行器
-        chatSubagentExecutor = ChatSubagentExecutor(
-            mcpManager = mcpManager,
-            localTools = localTools,
-            skillManager = skillManager
-        )
-        chatState.subagentToolExecutor = chatSubagentExecutor?.createToolExecutor(settings.value)
-
         // 添加对话引用
         chatService.addConversationReference(_conversationId)
 
         // 初始化对话
         viewModelScope.launch {
             chatService.initializeConversation(_conversationId)
-        }
-
-        // 同步对话内容到 chatState
-        viewModelScope.launch {
-            conversation.collect { conv ->
-                // 只有在非加载状态下才从 Service 同步内容，避免覆盖流式生成的过程
-                if (!chatState.isLoading.value) {
-                    chatState.setNodes(conv.messageNodes)
-                }
-            }
-        }
-
-        chatState.onFinish = { result ->
-            viewModelScope.launch {
-                // 将最终生成的完整消息保存到数据库
-                chatService.updateConversationState(_conversationId) { conv ->
-                    conv.copy(
-                        messageNodes = conv.messageNodes + result.message.toMessageNode()
-                    )
-                }
-                chatService.saveConversation(_conversationId, conversation.value)
-            }
         }
 
         // 记住对话ID, 方便下次启动恢复
@@ -251,27 +194,7 @@ class ChatVM(
         if (content.isEmptyInputMessage()) return
         analytics.logEvent("ai_send_message", null)
 
-        val model = currentChatModel.value ?: return
-        val text = content.filterIsInstance<UIMessagePart.Text>().joinToString("") { it.text }
-        val attachments = content.filter { it !is UIMessagePart.Text }
-
-        // 更新 subagent 工具执行器（设置可能已更改）
-        if (chatSubagentExecutor != null) {
-            chatState.subagentToolExecutor = chatSubagentExecutor?.createToolExecutor(settings.value)
-        }
-
-        // 检查是否启用 subagent 模式
-        val useSubagent = enableSubagent.value
-
-        if (answer) {
-            // 先保存用户消息到 DB
-            chatService.sendMessage(_conversationId, content, answer = false)
-            // 触发 AI 生成（根据设置决定是否使用 subagent）
-            chatState.handleSubmit(model, text, attachments, addMessage = false, useSubagent = useSubagent)
-        } else {
-            // 如果不触发生成，仍然使用 service 保存消息
-            chatService.sendMessage(_conversationId, content, false)
-        }
+        chatService.sendMessage(_conversationId, content, answer)
     }
 
     fun handleMessageEdit(parts: List<UIMessagePart>, messageId: Uuid) {
@@ -320,7 +243,16 @@ class ChatVM(
         regenerateAssistantMsg: Boolean = true
     ) {
         analytics.logEvent("ai_regenerate_at_message", null)
+        regeneratingNodeId = if (message.role == com.eterultimate.eteruee.ai.core.MessageRole.ASSISTANT && regenerateAssistantMsg) {
+            conversation.value.getMessageNodeByMessageId(message.id)?.id
+        } else {
+            null
+        }
         chatService.regenerateAtMessage(_conversationId, message, regenerateAssistantMsg)
+    }
+
+    fun clearRegeneratingNode() {
+        regeneratingNodeId = null
     }
 
     fun handleToolApproval(
@@ -341,7 +273,6 @@ class ChatVM(
     }
 
     fun stopGeneration() {
-        chatState.stop()
         viewModelScope.launch {
             chatService.stopGeneration(_conversationId)
         }


### PR DESCRIPTION
## Summary
- Route chat sends through ChatService so generation uses the full transformer/tool/save pipeline instead of the simplified ChatStateHolder path.
- Preserve OpenAI streaming chunks by leaving normal null finish_reason values as null instead of converting them to "unknown".
- Show an inline loading indicator on the target assistant message while regenerating, while keeping normal sends on the bottom loading indicator.

## Evidence
- ChatCompletionsAPI previously assigned finishReason = "unknown" when OpenAI stream chunks omitted finish_reason, which made DefaultAISDK convert ordinary text deltas into TextChunk.Finish.
- ChatPage still read loading from ChatStateHolder while ChatService owns generation jobs, so regenerated messages had no target loading state.

## Verification
- .\gradlew :ai:testDebugUnitTest --tests "com.eterultimate.eteruee.ai.sdk.DefaultAISDKTest"
- .\gradlew :app:compileDebugKotlin

## Summary by Sourcery

Route chat message generation entirely through ChatService and align UI loading states with service-managed jobs while fixing OpenAI streaming chunk handling.

Bug Fixes:
- Preserve streaming text chunks from OpenAI by treating missing finish_reason values as null instead of premature finishes.
- Ensure regenerated assistant messages show an appropriate loading state by decoupling ChatPage loading from the removed ChatStateHolder and tracking the regenerating node in ViewModel.

Enhancements:
- Simplify ChatVM dependencies by removing direct AISDK and tool/subagent executors in favor of ChatService-managed conversations and jobs.
- Add inline loading indicators on assistant messages being regenerated while keeping the global bottom loading indicator for normal generations.
- Expose a MessageChunk.toTextChunk extension to convert message chunks to text chunks in a reusable way.

Tests:
- Add unit tests for DefaultAISDK MessageChunk.toTextChunk conversion to verify correct handling of text deltas and finish reasons.