### PR TITLE
Optimize prompt cache stability

### DIFF
--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/GenerationHandler.kt
@@ -121,7 +121,7 @@ class GenerationHandler(
                     ).let(this::addAll)
                 }
                 addAll(tools)
-            }
+            }.sortedBy { it.name }
 
             // Check if we have tool calls ready to continue after user interaction.
             val pendingTools = messages.lastOrNull()?.getTools()?.filter {

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/MemoryTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/MemoryTools.kt
@@ -14,8 +14,6 @@ import com.eterultimate.eteruee.ai.core.InputSchema
 import com.eterultimate.eteruee.ai.core.Tool
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
 import com.eterultimate.eteruee.data.model.AssistantMemory
-import com.eterultimate.eteruee.utils.toLocalString
-import java.time.LocalDate
 
 fun buildMemoryTools(
     json: Json,
@@ -35,7 +33,7 @@ fun buildMemoryTools(
             Do not store sensitive information (e.g., ethnicity, religion, sexual orientation, political views, sex life, criminal records).
             You may store: preferred name, preferences, plans, work-related notes, chat style preferences, first chat time, etc.
             Do not show memory content directly in the conversation unless the user explicitly asks.
-            Today is ${LocalDate.now().toLocalString(true)}.
+            Use the conversation's runtime context when date-sensitive memory wording is needed.
             Similar memories should be merged; prefer updating existing records.
 
             Examples:

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SearchTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SearchTools.kt
@@ -10,10 +10,8 @@ import com.eterultimate.eteruee.ai.core.Tool
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
 import com.eterultimate.eteruee.data.datastore.Settings
 import com.eterultimate.eteruee.utils.JsonInstantPretty
-import com.eterultimate.eteruee.utils.toLocalString
 import com.eterultimate.eteruee.search.SearchService
 import com.eterultimate.eteruee.search.SearchServiceOptions
-import java.time.LocalDate
 import kotlin.uuid.Uuid
 
 fun createSearchTools(settings: Settings): Set<Tool> {
@@ -25,7 +23,7 @@ fun createSearchTools(settings: Settings): Set<Tool> {
                     Search the web for up-to-date or specific information.
                     Use this when the user asks for the latest news, current facts, or needs verification.
                     Generate focused keywords and run multiple searches if needed.
-                    Today is ${LocalDate.now().toLocalString(true)}.
+                    Use the conversation's runtime context for today's date when forming time-sensitive queries.
 
                     Response format:
                     - items[].id (short id), title, url, text

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
@@ -64,7 +64,8 @@ fun createSkillTools(
                 val name = it.jsonObject["name"]?.jsonPrimitive?.content
                     ?: error("name is required")
                 if (name !in enabledSkills) {
-                    error("Skill '$name' is not available. Available skills: ${enabledSkills.sorted().joinToString()}")
+                    val availableNames = available.map { skill -> skill.name }.sorted()
+                    error("Skill '$name' is not available. Available skills: ${availableNames.joinToString()}")
                 }
                 val path = it.jsonObject["path"]?.jsonPrimitive?.content
                 val content = if (path.isNullOrBlank()) {

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/SkillsTools.kt
@@ -15,7 +15,9 @@ fun createSkillTools(
     allSkills: List<SkillMetadata>,
     skillManager: SkillManager,
 ): List<Tool> {
-    val available = allSkills.filter { it.name in enabledSkills }
+    val available = allSkills
+        .filter { it.name in enabledSkills }
+        .sortedWith(compareBy<SkillMetadata> { it.name }.thenBy { it.description })
     if (available.isEmpty()) return emptyList()
 
     return listOf(
@@ -62,7 +64,7 @@ fun createSkillTools(
                 val name = it.jsonObject["name"]?.jsonPrimitive?.content
                     ?: error("name is required")
                 if (name !in enabledSkills) {
-                    error("Skill '$name' is not available. Available skills: ${enabledSkills.joinToString()}")
+                    error("Skill '$name' is not available. Available skills: ${enabledSkills.sorted().joinToString()}")
                 }
                 val path = it.jsonObject["path"]?.jsonPrimitive?.content
                 val content = if (path.isNullOrBlank()) {

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformer.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformer.kt
@@ -272,6 +272,8 @@ private fun buildRuntimeContextMessage(
         }
         append("</runtime_context>")
     }
+    // Keep this as a synthetic user turn: PromptInjection has already run, and
+    // some providers handle mid-conversation SYSTEM messages inconsistently.
     return UIMessage.user(content)
 }
 

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformer.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformer.kt
@@ -6,12 +6,12 @@ import android.os.Build
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import com.eterultimate.eteruee.ai.core.MessageRole
 import com.eterultimate.eteruee.ai.provider.Model
 import com.eterultimate.eteruee.ai.ui.UIMessage
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
 import com.eterultimate.eteruee.R
 import com.eterultimate.eteruee.data.datastore.SettingsStore
-import com.eterultimate.eteruee.data.datastore.getCurrentAssistant
 import com.eterultimate.eteruee.data.model.Assistant
 import com.eterultimate.eteruee.utils.LocationProvider
 import org.koin.core.component.KoinComponent
@@ -36,8 +36,14 @@ interface PlaceholderProvider {
     val placeholders: Map<String, PlaceholderInfo>
 }
 
+enum class PlaceholderCachePolicy {
+    STABLE,
+    RUNTIME,
+}
+
 data class PlaceholderInfo(
     val displayName: @Composable () -> Unit,
+    val cachePolicy: PlaceholderCachePolicy = PlaceholderCachePolicy.STABLE,
     val resolver: (PlaceholderCtx) -> String
 )
 
@@ -47,9 +53,10 @@ class PlaceholderBuilder {
     fun placeholder(
         key: String,
         displayName: @Composable () -> Unit,
+        cachePolicy: PlaceholderCachePolicy = PlaceholderCachePolicy.STABLE,
         resolver: (PlaceholderCtx) -> String
     ) {
-        placeholders[key] = PlaceholderInfo(displayName, resolver)
+        placeholders[key] = PlaceholderInfo(displayName, cachePolicy, resolver)
     }
 
     fun build(): Map<String, PlaceholderInfo> = placeholders.toMap()
@@ -61,15 +68,27 @@ fun buildPlaceholders(block: PlaceholderBuilder.() -> Unit): Map<String, Placeho
 
 object DefaultPlaceholderProvider : PlaceholderProvider {
     override val placeholders: Map<String, PlaceholderInfo> = buildPlaceholders {
-        placeholder("cur_date", { Text(stringResource(R.string.placeholder_current_date)) }) {
+        placeholder(
+            "cur_date",
+            { Text(stringResource(R.string.placeholder_current_date)) },
+            PlaceholderCachePolicy.RUNTIME
+        ) {
             LocalDate.now().toDateString()
         }
 
-        placeholder("cur_time", { Text(stringResource(R.string.placeholder_current_time)) }) {
+        placeholder(
+            "cur_time",
+            { Text(stringResource(R.string.placeholder_current_time)) },
+            PlaceholderCachePolicy.RUNTIME
+        ) {
             LocalTime.now().toTimeString()
         }
 
-        placeholder("cur_datetime", { Text(stringResource(R.string.placeholder_current_datetime)) }) {
+        placeholder(
+            "cur_datetime",
+            { Text(stringResource(R.string.placeholder_current_datetime)) },
+            PlaceholderCachePolicy.RUNTIME
+        ) {
             LocalDateTime.now().toDateTimeString()
         }
 
@@ -97,7 +116,11 @@ object DefaultPlaceholderProvider : PlaceholderProvider {
             "${Build.BRAND} ${Build.MODEL}"
         }
 
-        placeholder("battery_level", { Text(stringResource(R.string.placeholder_battery_level)) }) {
+        placeholder(
+            "battery_level",
+            { Text(stringResource(R.string.placeholder_battery_level)) },
+            PlaceholderCachePolicy.RUNTIME
+        ) {
             it.context.batteryLevel().toString()
         }
 
@@ -113,7 +136,11 @@ object DefaultPlaceholderProvider : PlaceholderProvider {
             it.settingsStore.settingsFlow.value.displaySetting.userNickname.ifBlank { "user" }
         }
 
-        placeholder("current_location", { Text(stringResource(R.string.placeholder_current_location)) }) {
+        placeholder(
+            "current_location",
+            { Text(stringResource(R.string.placeholder_current_location)) },
+            PlaceholderCachePolicy.RUNTIME
+        ) {
             LocationProvider.getCurrentLocation(it.context)
         }
     }
@@ -147,42 +174,122 @@ object PlaceholderTransformer : InputMessageTransformer, KoinComponent {
         messages: List<UIMessage>,
     ): List<UIMessage> {
         val settingsStore = get<SettingsStore>()
-        return messages.map {
-            it.copy(
-                parts = it.parts.map { part ->
-                    if (part is UIMessagePart.Text) {
-                        part.copy(
-                            text = replacePlaceholders(text = part.text, ctx = ctx, settingsStore = settingsStore)
-                        )
-                    } else {
-                        part
-                    }
-                }
-            )
-        }
-    }
-
-    private fun replacePlaceholders(
-        text: String,
-        ctx: TransformerContext,
-        settingsStore: SettingsStore
-    ): String {
-        var result = text
-
-        val ctx = PlaceholderCtx(
+        val placeholderCtx = PlaceholderCtx(
             context = ctx.context,
             settingsStore = settingsStore,
             model = ctx.model,
             assistant = ctx.assistant
         )
-        defaultProvider.placeholders.forEach { (key, placeholderInfo) ->
-            val value = placeholderInfo.resolver(ctx)
-            result = result
-                .replace(oldValue = "{{$key}}", newValue = value, ignoreCase = true)
-                .replace(oldValue = "{$key}", newValue = value, ignoreCase = true)
-        }
-
-        return result
+        return applyPlaceholdersForCache(
+            messages = messages,
+            placeholders = defaultProvider.placeholders,
+            placeholderCtx = placeholderCtx,
+        )
     }
+}
+
+internal fun applyPlaceholdersForCache(
+    messages: List<UIMessage>,
+    placeholders: Map<String, PlaceholderInfo>,
+    placeholderCtx: PlaceholderCtx,
+): List<UIMessage> {
+    return applyPlaceholdersForCache(
+        messages = messages,
+        placeholders = placeholders,
+        resolvePlaceholder = { _, placeholder -> placeholder.resolver(placeholderCtx) },
+    )
+}
+
+internal fun applyPlaceholdersForCache(
+    messages: List<UIMessage>,
+    placeholders: Map<String, PlaceholderInfo>,
+    resolvePlaceholder: (key: String, placeholder: PlaceholderInfo) -> String,
+): List<UIMessage> {
+    val systemRuntimeKeys = linkedSetOf<String>()
+    val transformed = messages.map { message ->
+        message.copy(
+            parts = message.parts.map { part ->
+                if (part is UIMessagePart.Text) {
+                    val text = replacePlaceholders(
+                        text = part.text,
+                        role = message.role,
+                        placeholders = placeholders,
+                        resolvePlaceholder = resolvePlaceholder,
+                        systemRuntimeKeys = systemRuntimeKeys,
+                    )
+                    part.copy(text = text)
+                } else {
+                    part
+                }
+            }
+        )
+    }
+
+    if (systemRuntimeKeys.isEmpty()) return transformed
+
+    return transformed.toMutableList().apply {
+        add(
+            runtimeContextInsertIndex(transformed),
+            buildRuntimeContextMessage(systemRuntimeKeys, placeholders, resolvePlaceholder)
+        )
+    }
+}
+
+private fun replacePlaceholders(
+    text: String,
+    role: MessageRole,
+    placeholders: Map<String, PlaceholderInfo>,
+    resolvePlaceholder: (key: String, placeholder: PlaceholderInfo) -> String,
+    systemRuntimeKeys: MutableSet<String>,
+): String {
+    var result = text
+    placeholders.forEach { (key, placeholderInfo) ->
+        if (!result.containsPlaceholder(key)) return@forEach
+
+        val value = if (role == MessageRole.SYSTEM && placeholderInfo.cachePolicy == PlaceholderCachePolicy.RUNTIME) {
+            systemRuntimeKeys.add(key)
+            "<runtime_context>$key</runtime_context>"
+        } else {
+            resolvePlaceholder(key, placeholderInfo)
+        }
+        result = result.replacePlaceholder(key, value)
+    }
+    return result
+}
+
+private fun buildRuntimeContextMessage(
+    keys: Set<String>,
+    placeholders: Map<String, PlaceholderInfo>,
+    resolvePlaceholder: (key: String, placeholder: PlaceholderInfo) -> String,
+): UIMessage {
+    val content = buildString {
+        appendLine("<runtime_context>")
+        appendLine("Dynamic values referenced by the stable system prompt:")
+        keys.sorted().forEach { key ->
+            val placeholder = placeholders[key] ?: return@forEach
+            val value = resolvePlaceholder(key, placeholder)
+            appendLine("- $key: $value")
+        }
+        append("</runtime_context>")
+    }
+    return UIMessage.user(content)
+}
+
+private fun runtimeContextInsertIndex(messages: List<UIMessage>): Int {
+    if (messages.isEmpty()) return 0
+    val firstNonSystemIndex = messages.indexOfFirst { it.role != MessageRole.SYSTEM }
+        .takeIf { it >= 0 }
+        ?: messages.size
+    val targetIndex = (messages.size - 1).coerceAtLeast(firstNonSystemIndex)
+    return findSafeInsertIndex(messages, targetIndex)
+}
+
+private fun String.containsPlaceholder(key: String): Boolean {
+    return contains("{{$key}}", ignoreCase = true) || contains("{$key}", ignoreCase = true)
+}
+
+private fun String.replacePlaceholder(key: String, value: String): String {
+    return replace(oldValue = "{{$key}}", newValue = value, ignoreCase = true)
+        .replace(oldValue = "{$key}", newValue = value, ignoreCase = true)
 }
 

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TemplateTransformer.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TemplateTransformer.kt
@@ -2,6 +2,10 @@
 
 import io.pebbletemplates.pebble.PebbleEngine
 import io.pebbletemplates.pebble.loader.Loader
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlin.time.toJavaInstant
+import com.eterultimate.eteruee.ai.core.MessageRole
 import com.eterultimate.eteruee.ai.ui.UIMessage
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
 import com.eterultimate.eteruee.data.datastore.SettingsStore
@@ -10,7 +14,6 @@ import com.eterultimate.eteruee.utils.toLocalTime
 import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
-import java.time.Instant
 
 class TemplateTransformer(
     private val engine: PebbleEngine,
@@ -22,6 +25,11 @@ class TemplateTransformer(
     ): List<UIMessage> {
         val template = engine.getTemplate(ctx.assistant.id.toString())
         return messages.map { message ->
+            if (message.role == MessageRole.SYSTEM) return@map message
+
+            val messageInstant = message.createdAt
+                .toInstant(TimeZone.currentSystemDefault())
+                .toJavaInstant()
             message.copy(
                 parts = message.parts.map { part ->
                     when (part) {
@@ -31,8 +39,8 @@ class TemplateTransformer(
                                 result, mapOf(
                                     "message" to part.text,
                                     "role" to message.role.name.lowercase(),
-                                    "time" to Instant.now().toLocalTime(),
-                                    "date" to Instant.now().toLocalDate(),
+                                    "time" to messageInstant.toLocalTime(),
+                                    "date" to messageInstant.toLocalDate(),
                                 )
                             )
                             part.copy(

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TemplateTransformer.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TemplateTransformer.kt
@@ -25,6 +25,8 @@ class TemplateTransformer(
     ): List<UIMessage> {
         val template = engine.getTemplate(ctx.assistant.id.toString())
         return messages.map { message ->
+            // System placeholders are handled by PlaceholderTransformer; templating
+            // the stable prefix here would reintroduce per-request mutations.
             if (message.role == MessageRole.SYSTEM) return@map message
 
             val messageInstant = message.createdAt

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TimeReminderTransformer.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/transformers/TimeReminderTransformer.kt
@@ -40,7 +40,10 @@ internal fun applyTimeReminder(messages: List<UIMessage>): List<UIMessage> {
             val gapSeconds = (currInstant - prevInstant).inWholeSeconds
 
             if (gapSeconds > TIME_GAP_THRESHOLD_SECONDS) {
-                result.add(buildTimeReminderMessage(gapSeconds, currInstant))
+                result.add(
+                    buildTimeReminderMessage(gapSeconds, currInstant)
+                        .copy(createdAt = current.createdAt)
+                )
             }
         }
         result.add(current)

--- a/app/src/test/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformerTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/data/ai/transformers/PlaceholderTransformerTest.kt
@@ -1,0 +1,123 @@
+package com.eterultimate.eteruee.data.ai.transformers
+
+import com.eterultimate.eteruee.ai.core.MessageRole
+import com.eterultimate.eteruee.ai.ui.UIMessage
+import com.eterultimate.eteruee.ai.ui.UIMessagePart
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaceholderTransformerTest {
+    private val placeholders = mapOf(
+        "cur_datetime" to PlaceholderInfo(
+            displayName = {},
+            cachePolicy = PlaceholderCachePolicy.RUNTIME,
+            resolver = { error("not used by pure test") }
+        ),
+        "battery_level" to PlaceholderInfo(
+            displayName = {},
+            cachePolicy = PlaceholderCachePolicy.RUNTIME,
+            resolver = { error("not used by pure test") }
+        ),
+        "model_name" to PlaceholderInfo(
+            displayName = {},
+            resolver = { error("not used by pure test") }
+        )
+    )
+
+    @Test
+    fun `runtime system placeholders should ride tail context`() {
+        val messages = listOf(
+            UIMessage.system("Model {{model_name}}\nTime {{cur_datetime}}\nBattery {battery_level}"),
+            UIMessage.user("Hello")
+        )
+
+        val result = applyPlaceholdersForCache(
+            messages = messages,
+            placeholders = placeholders,
+            resolvePlaceholder = { key, _ ->
+                when (key) {
+                    "cur_datetime" -> "Jun 11, 2026, 10:30:00 AM"
+                    "battery_level" -> "88"
+                    "model_name" -> "DeepSeek"
+                    else -> error("unexpected key $key")
+                }
+            }
+        )
+
+        assertEquals(3, result.size)
+        val systemText = result[0].toText()
+        assertEquals(MessageRole.SYSTEM, result[0].role)
+        assertTrue(systemText.contains("Model DeepSeek"))
+        assertTrue(systemText.contains("<runtime_context>cur_datetime</runtime_context>"))
+        assertTrue(systemText.contains("<runtime_context>battery_level</runtime_context>"))
+        assertFalse(systemText.contains("Jun 11, 2026"))
+        assertFalse(systemText.contains("88"))
+
+        val runtimeText = result[1].toText()
+        assertEquals(MessageRole.USER, result[1].role)
+        assertTrue(runtimeText.contains("- battery_level: 88"))
+        assertTrue(runtimeText.contains("- cur_datetime: Jun 11, 2026, 10:30:00 AM"))
+        assertEquals("Hello", result[2].toText())
+    }
+
+    @Test
+    fun `runtime user placeholders should resolve in place`() {
+        val messages = listOf(UIMessage.user("Current time: {{cur_datetime}}"))
+
+        val result = applyPlaceholdersForCache(
+            messages = messages,
+            placeholders = placeholders,
+            resolvePlaceholder = { key, _ ->
+                when (key) {
+                    "cur_datetime" -> "Jun 11, 2026, 10:30:00 AM"
+                    else -> error("unexpected key $key")
+                }
+            }
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("Current time: Jun 11, 2026, 10:30:00 AM", result[0].toText())
+    }
+
+    @Test
+    fun `runtime context should not split user tool-call adjacency`() {
+        val messages = listOf(
+            UIMessage.system("Time {{cur_datetime}}"),
+            UIMessage.user("Call a tool"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call_1",
+                        toolName = "search_web",
+                        input = "{}",
+                        output = emptyList()
+                    )
+                )
+            )
+        )
+
+        val result = applyPlaceholdersForCache(
+            messages = messages,
+            placeholders = placeholders,
+            resolvePlaceholder = { key, _ ->
+                when (key) {
+                    "cur_datetime" -> "Jun 11, 2026, 10:30:00 AM"
+                    else -> error("unexpected key $key")
+                }
+            }
+        )
+
+        val expectedRuntimeContext = """
+            <runtime_context>
+            Dynamic values referenced by the stable system prompt:
+            - cur_datetime: Jun 11, 2026, 10:30:00 AM
+            </runtime_context>
+        """.trimIndent()
+        assertEquals(expectedRuntimeContext, result[1].toText())
+        assertEquals("Call a tool", result[2].toText())
+        assertTrue(result[3].getTools().isNotEmpty())
+    }
+}

--- a/app/src/test/java/com/eterultimate/eteruee/data/ai/transformers/TimeReminderTransformerTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/data/ai/transformers/TimeReminderTransformerTest.kt
@@ -1,0 +1,36 @@
+package com.eterultimate.eteruee.data.ai.transformers
+
+import com.eterultimate.eteruee.ai.core.MessageRole
+import com.eterultimate.eteruee.ai.ui.UIMessage
+import com.eterultimate.eteruee.ai.ui.UIMessagePart
+import kotlinx.datetime.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimeReminderTransformerTest {
+    @Test
+    fun `inserted reminder should use following message timestamp`() {
+        val firstCreatedAt = LocalDateTime(2026, 6, 11, 8, 0)
+        val secondCreatedAt = LocalDateTime(2026, 6, 11, 10, 0)
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.USER,
+                parts = listOf(UIMessagePart.Text("First")),
+                createdAt = firstCreatedAt
+            ),
+            UIMessage(
+                role = MessageRole.USER,
+                parts = listOf(UIMessagePart.Text("Second")),
+                createdAt = secondCreatedAt
+            )
+        )
+
+        val result = applyTimeReminder(messages)
+
+        assertEquals(3, result.size)
+        assertTrue(result[1].toText().contains("<time_reminder>"))
+        assertEquals(secondCreatedAt, result[1].createdAt)
+        assertEquals(secondCreatedAt, result[2].createdAt)
+    }
+}


### PR DESCRIPTION
## Summary
- keep runtime placeholders out of the stable system prefix by replacing system-time/device placeholders with runtime-context references and injecting current values near the latest turn
- make message template date/time values derive from each message timestamp and skip templating system messages
- remove per-day dates from tool descriptions, stabilize skill/tool ordering, and keep generated time-reminder timestamps stable

## Reasonix reference
DeepSeek-Reasonix keeps base prompt, tools, and durable memory byte-stable, while transient data rides the user-turn tail. This applies the same pattern to EterUee's generation path without adding local caching.

## Tests
- `ANDROID_HOME=C:\Users\zacza\AppData\Local\Android\Sdk .\gradlew.bat :app:testDebugUnitTest --tests "com.eterultimate.eteruee.data.ai.transformers.PlaceholderTransformerTest" --tests "com.eterultimate.eteruee.data.ai.transformers.TimeReminderTransformerTest"`

## Summary by Sourcery

Stabilize prompt-related context by separating runtime-dependent values from the stable system prompt and aligning timestamps and tool metadata with message context for better cacheability.

New Features:
- Introduce placeholder cache policies that allow runtime-only values to be routed through a dedicated runtime context message instead of the stable system prompt.

Bug Fixes:
- Make message template date/time values derive from each message's timestamp rather than the current time.
- Ensure inserted time reminder messages inherit the following message's timestamp to keep temporal metadata consistent.

Enhancements:
- Refactor placeholder application to support cache-aware handling of system and user messages and centralize placeholder resolution.
- Prevent templating from being applied to system messages to keep the base system prompt stable.
- Stabilize skill and tool ordering and error messages by sorting skills and tools deterministically.
- Update memory and search tool descriptions to avoid embedding the current date directly and instead refer to the conversation runtime context.

Tests:
- Add unit tests covering runtime placeholder behavior, runtime context insertion, and time reminder timestamp handling.