### PR TITLE
Expose local runtime integrations to LLM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,6 +182,15 @@ android {
         jniLibs {
             useLegacyPackaging = true
         }
+        resources {
+            excludes += setOf(
+                "aix/**",
+                "darwin/**",
+                "freebsd/**",
+                "linux/**",
+                "win/**",
+            )
+        }
     }
     externalNativeBuild {
         cmake {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -352,6 +352,7 @@ dependencies {
 
     // Apache Commons Text
     implementation(libs.commons.text)
+    implementation(libs.commons.compress)
 
     // Toast (Sonner)
     implementation(libs.sonner)
@@ -388,6 +389,10 @@ dependencies {
     // Shizuku privileged shell/API bridge
     implementation(libs.shizuku.api)
     implementation(libs.shizuku.provider)
+
+    // Arch Linux rootfs extraction
+    implementation(libs.xz)
+    implementation(libs.zstd.jni)
 
     // modules
     implementation(project(":ai"))

--- a/app/src/main/java/com/eterultimate/eteruee/RouteActivity.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/RouteActivity.kt
@@ -1,13 +1,17 @@
 package com.eterultimate.eteruee
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.fadeIn
@@ -36,8 +40,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -55,8 +61,11 @@ import coil3.svg.SvgDecoder
 import com.dokar.sonner.Toaster
 import com.dokar.sonner.rememberToasterState
 import kotlinx.serialization.Serializable
+import com.eterultimate.eteruee.ai.provider.ProviderSetting
+import com.eterultimate.eteruee.data.ai.mcp.McpServerConfig
 import com.eterultimate.eteruee.highlight.Highlighter
 import com.eterultimate.eteruee.highlight.LocalHighlighter
+import com.eterultimate.eteruee.data.datastore.Settings
 import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.data.db.DatabaseMigrationTracker
 import com.eterultimate.eteruee.data.db.MigrationState
@@ -129,18 +138,27 @@ import com.eterultimate.eteruee.roleplay.ui.pages.bookmark.BookmarkPage
 import com.eterultimate.eteruee.ui.theme.LocalDarkMode
 import com.eterultimate.eteruee.ui.theme.EterUeeTheme
 import com.eterultimate.eteruee.utils.CrashHandler
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.koin.android.ext.android.inject
 import org.koin.compose.koinInject
 import kotlin.uuid.Uuid
 
 private const val TAG = "RouteActivity"
+private const val LOCAL_NETWORK_PERMISSION_PREFS = "runtime_permissions"
+private const val LOCAL_NETWORK_PERMISSION_REQUESTED = "local_network_requested"
 
 class RouteActivity : ComponentActivity() {
     private val highlighter by inject<Highlighter>()
     private val okHttpClient by inject<OkHttpClient>()
     private val settingsStore by inject<SettingsStore>()
     private var navStack: MutableList<NavKey>? = null
+    private val localNetworkPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        Log.i(TAG, "ACCESS_LOCAL_NETWORK permission granted: $granted")
+    }
 
     // Volume key listener registry — last registered handler wins
     internal val volumeKeyListeners = mutableListOf<(isVolumeUp: Boolean) -> Boolean>()
@@ -167,6 +185,7 @@ class RouteActivity : ComponentActivity() {
             finish()
             return
         }
+        requestLocalNetworkPermissionForRuntimeAccess()
         setContent {
             EterUeeTheme {
                 setSingletonImageLoaderFactory { context ->
@@ -194,6 +213,29 @@ class RouteActivity : ComponentActivity() {
     private fun disableNavigationBarContrast() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isNavigationBarContrastEnforced = false
+        }
+    }
+
+    private fun requestLocalNetworkPermissionForRuntimeAccess() {
+        if (Build.VERSION.SDK_INT < 37) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_LOCAL_NETWORK,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        val prefs = getSharedPreferences(LOCAL_NETWORK_PERMISSION_PREFS, MODE_PRIVATE)
+        if (prefs.getBoolean(LOCAL_NETWORK_PERMISSION_REQUESTED, false)) return
+
+        lifecycleScope.launch {
+            val settings = runCatching { settingsStore.settingsFlowRaw.first() }.getOrNull()
+                ?: return@launch
+            if (!settings.usesLocalNetworkRuntime()) return@launch
+
+            prefs.edit().putBoolean(LOCAL_NETWORK_PERMISSION_REQUESTED, true).apply()
+            localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
         }
     }
 
@@ -646,6 +688,37 @@ class RouteActivity : ComponentActivity() {
             }
         }
     }
+}
+
+private fun Settings.usesLocalNetworkRuntime(): Boolean {
+    val hasLocalMcpServer = mcpServers.any { server ->
+        server.commonOptions.enable && server.endpointUrl()?.isLocalNetworkEndpoint() == true
+    }
+    val hasLocalProvider = providers.any { provider ->
+        provider.enabled && provider.endpointUrl()?.isLocalNetworkEndpoint() == true
+    }
+    return hasLocalMcpServer || hasLocalProvider
+}
+
+private fun McpServerConfig.endpointUrl(): String? = when (this) {
+    is McpServerConfig.SseTransportServer -> url
+    is McpServerConfig.StreamableHTTPServer -> url
+    is McpServerConfig.StdioTransportServer -> null
+}
+
+private fun ProviderSetting.endpointUrl(): String? = when (this) {
+    is ProviderSetting.OpenAI -> baseUrl
+    is ProviderSetting.Google -> baseUrl
+    is ProviderSetting.Claude -> baseUrl
+}
+
+private fun String.isLocalNetworkEndpoint(): Boolean {
+    val host = runCatching { toUri().host?.lowercase() }.getOrNull() ?: return false
+    if (host == "localhost" || host == "::1" || host.endsWith(".local")) return true
+    if (host.startsWith("127.") || host.startsWith("10.") || host.startsWith("192.168.")) return true
+    if (host.startsWith("169.254.")) return true
+    val parts = host.split('.').mapNotNull { it.toIntOrNull() }
+    return parts.size == 4 && parts[0] == 172 && parts[1] in 16..31
 }
 
 sealed interface Screen : NavKey {

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/LocalTools.kt
@@ -24,6 +24,7 @@ import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.device.DeviceAgentManager
 import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.repository.GenMediaRepository
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
 import com.eterultimate.eteruee.network.HiddifyCoreManager
 import com.eterultimate.eteruee.utils.readClipboardText
 import com.eterultimate.eteruee.utils.writeClipboardText
@@ -71,6 +72,10 @@ sealed class LocalToolOption {
     @Serializable
     @SerialName("shell")
     data object Shell : LocalToolOption()
+
+    @Serializable
+    @SerialName("linux_environment")
+    data object LinuxEnvironment : LocalToolOption()
 
     @Serializable
     @SerialName("traffic_control")
@@ -258,6 +263,7 @@ class LocalTools(
     private val eventBus: AppEventBus,
     private val hiddifyCoreManager: HiddifyCoreManager,
     private val deviceAgentManager: DeviceAgentManager,
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
     private val settingsStore: SettingsStore,
     private val providerManager: ProviderManager,
     private val filesManager: FilesManager,
@@ -538,7 +544,9 @@ class LocalTools(
 
     val sshTool by lazy { SshTools.createSshExecuteTool() }
 
-    val shellTool by lazy { ShellTools.createShellExecuteTool(context) }
+    val shellTool by lazy { ShellTools.createShellExecuteTool(context, linuxEnvironmentManager) }
+
+    val linuxEnvironmentTool by lazy { ShellTools.createLinuxEnvironmentTool(linuxEnvironmentManager) }
 
     val trafficControlTool by lazy { TrafficControlTools.createTrafficControlTool(hiddifyCoreManager) }
 
@@ -580,6 +588,9 @@ class LocalTools(
         }
         if (options.contains(LocalToolOption.Shell)) {
             tools.add(shellTool)
+        }
+        if (options.contains(LocalToolOption.LinuxEnvironment)) {
+            tools.add(linuxEnvironmentTool)
         }
         if (options.contains(LocalToolOption.TrafficControl)) {
             tools.add(trafficControlTool)

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/ShellTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/tools/ShellTools.kt
@@ -4,20 +4,28 @@ import android.content.Context
 import com.eterultimate.eteruee.ai.core.InputSchema
 import com.eterultimate.eteruee.ai.core.Tool
 import com.eterultimate.eteruee.ai.ui.UIMessagePart
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
 import com.eterultimate.eteruee.shell.LocalShellRunner
+import com.eterultimate.eteruee.utils.JsonInstant
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 object ShellTools {
 
-    fun createShellExecuteTool(context: Context): Tool = Tool(
+    fun createShellExecuteTool(
+        context: Context,
+        linuxEnvironmentManager: LinuxEnvironmentManager,
+    ): Tool = Tool(
         name = "shell_execute",
         description = """
             Execute a shell command on the local device through EterUee's built-in Termux terminal layer.
-            No external Termux app is required. Commands run in an app-local Android shell environment.
+            No external Termux app is required. By default, EterUee uses the managed Arch Linux/proot
+            environment when it is installed; otherwise it falls back to the app-local Android shell.
             Returns stdout, stderr, exit code, shell path, and working directory.
             Use for local file operations, system info, and app-scoped automation.
         """.trimIndent().replace("\n", " "),
@@ -41,6 +49,11 @@ object ShellTools {
                         put("description", "Command execution timeout in seconds (default: 30)")
                         put("default", 30)
                     })
+                    put("environment", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Execution environment: auto, linux, or android. Default: auto")
+                        put("default", "auto")
+                    })
                 },
                 required = listOf("command")
             )
@@ -52,26 +65,137 @@ object ShellTools {
                 ?: error("command is required")
             val workingDir = jsonObject["workingDir"]?.jsonPrimitive?.contentOrNull
             val stdin = jsonObject["stdin"]?.jsonPrimitive?.contentOrNull
-            val timeout = jsonObject["timeout"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: 30
+            val timeout = jsonObject["timeout"]?.jsonPrimitive?.intOrNull
+                ?: jsonObject["timeout"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+                ?: 30
+            val environment = jsonObject["environment"]?.jsonPrimitive?.contentOrNull
+                ?.lowercase()
+                ?.takeIf { it.isNotBlank() }
+                ?: "auto"
 
-            val result = LocalShellRunner.executeBlocking(
-                context = context,
-                command = command,
-                workingDir = workingDir,
-                stdin = stdin,
-                timeoutSeconds = timeout,
-            )
-
-            val payload = buildJsonObject {
-                put("stdout", result.stdout)
-                put("stderr", result.stderr)
-                put("exitCode", result.exitCode)
-                put("executor", result.executor)
-                put("shell", result.shell)
-                put("workingDir", result.workingDir)
-                put("command", command)
+            val linuxStatus = linuxEnvironmentManager.getStatus()
+            if (environment !in setOf("auto", "linux", "android")) {
+                error("environment must be one of: auto, linux, android")
             }
-            listOf(UIMessagePart.Text(payload.toString()))
+
+            when {
+                environment != "android" && linuxStatus.canExecuteLinux -> {
+                    val result = linuxEnvironmentManager.execute(
+                        command = command,
+                        workingDir = workingDir,
+                        stdin = stdin,
+                        timeoutSeconds = timeout,
+                    )
+                    listOf(UIMessagePart.Text(JsonInstant.encodeToString(result)))
+                }
+
+                environment == "linux" -> {
+                    listOf(UIMessagePart.Text(JsonInstant.encodeToString(linuxStatus)))
+                }
+
+                else -> {
+                    val result = LocalShellRunner.executeBlocking(
+                        context = context,
+                        command = command,
+                        workingDir = workingDir,
+                        stdin = stdin,
+                        timeoutSeconds = timeout,
+                    )
+
+                    val payload = buildJsonObject {
+                        put("stdout", result.stdout)
+                        put("stderr", result.stderr)
+                        put("exitCode", result.exitCode)
+                        put("executor", result.executor)
+                        put("shell", result.shell)
+                        put("workingDir", result.workingDir)
+                        put("command", command)
+                        put("linux", JsonInstant.encodeToJsonElement(linuxStatus))
+                    }
+                    listOf(UIMessagePart.Text(payload.toString()))
+                }
+            }
+        }
+    )
+
+    fun createLinuxEnvironmentTool(
+        linuxEnvironmentManager: LinuxEnvironmentManager,
+    ): Tool = Tool(
+        name = "linux_environment",
+        description = """
+            Inspect or prepare EterUee's managed Arch Linux environment for LLM tools.
+            Actions: status returns rootfs/proot readiness; prepare writes the installer helper;
+            install downloads the Termux proot runtime and extracts the Arch rootfs after approval;
+            exec runs a command inside Arch Linux when installation is complete.
+        """.trimIndent().replace("\n", " "),
+        parameters = {
+            InputSchema.Obj(
+                properties = buildJsonObject {
+                    put("action", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Action: status, prepare, install, or exec")
+                    })
+                    put("command", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Command to run when action is exec")
+                    })
+                    put("workingDir", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Linux working directory for exec, default /root")
+                    })
+                    put("stdin", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Standard input for exec")
+                    })
+                    put("timeout", buildJsonObject {
+                        put("type", "integer")
+                        put("description", "Timeout in seconds. Default 60 for exec, up to 600 for install")
+                    })
+                },
+                required = listOf("action")
+            )
+        },
+        needsApproval = true,
+        execute = { params ->
+            val json = params.jsonObject
+            when (val action = json["action"]?.jsonPrimitive?.contentOrNull) {
+                "status" -> listOf(
+                    UIMessagePart.Text(JsonInstant.encodeToString(linuxEnvironmentManager.getStatus()))
+                )
+
+                "prepare" -> listOf(
+                    UIMessagePart.Text(JsonInstant.encodeToString(linuxEnvironmentManager.prepareInstallerScript()))
+                )
+
+                "install" -> listOf(
+                    UIMessagePart.Text(
+                        JsonInstant.encodeToString(
+                            linuxEnvironmentManager.install(
+                                timeoutSeconds = json["timeout"]?.jsonPrimitive?.intOrNull ?: 600,
+                            )
+                        )
+                    )
+                )
+
+                "exec" -> {
+                    val command = json["command"]?.jsonPrimitive?.contentOrNull
+                        ?: error("command is required when action is exec")
+                    listOf(
+                        UIMessagePart.Text(
+                            JsonInstant.encodeToString(
+                                linuxEnvironmentManager.execute(
+                                    command = command,
+                                    workingDir = json["workingDir"]?.jsonPrimitive?.contentOrNull,
+                                    stdin = json["stdin"]?.jsonPrimitive?.contentOrNull,
+                                    timeoutSeconds = json["timeout"]?.jsonPrimitive?.intOrNull ?: 60,
+                                )
+                            )
+                        )
+                    )
+                }
+
+                else -> error("action must be one of: status, prepare, install, exec; got $action")
+            }
         }
     )
 }

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/DefaultProviders.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/DefaultProviders.kt
@@ -14,6 +14,8 @@ import com.eterultimate.eteruee.ai.provider.Model
 import com.eterultimate.eteruee.ai.provider.ModelAbility
 import com.eterultimate.eteruee.ai.provider.ProviderSetting
 import com.eterultimate.eteruee.R
+import com.eterultimate.eteruee.data.ai.mcp.McpCommonOptions
+import com.eterultimate.eteruee.data.ai.mcp.McpServerConfig
 import com.eterultimate.eteruee.ui.components.richtext.MarkdownBlock
 import kotlin.uuid.Uuid
 
@@ -23,6 +25,10 @@ const val DEFAULT_ETERUEE_OFFICIAL_API_BASE_URL = "https://sapi.eterultimate.asi
 const val DEFAULT_ETERUEE_PROVIDER_BASE_URL = "$DEFAULT_ETERUEE_OFFICIAL_API_BASE_URL/v1"
 const val PREVIOUS_ETERUEE_PROVIDER_BASE_URL = "https://newapi.eterultimate.asia/v1"
 const val LEGACY_ETERUEE_PROVIDER_BASE_URL = "https://api.eteruee.com/v1"
+val DEFAULT_LOCAL_SAPI_PROVIDER_ID = Uuid.parse("0d68b477-5918-4a0e-8bdb-91e596ecf9d5")
+val DEFAULT_JSHOOK_MCP_SERVER_ID = Uuid.parse("27429a87-8db8-4f95-9f94-61ca3e82002e")
+const val DEFAULT_LOCAL_SAPI_PROVIDER_BASE_URL = "http://10.0.2.2:3000/v1"
+const val DEFAULT_JSHOOK_MCP_URL = "http://10.0.2.2:3001/mcp"
 
 val DEFAULT_PROVIDERS = listOf(
     ProviderSetting.OpenAI(
@@ -41,6 +47,30 @@ val DEFAULT_PROVIDERS = listOf(
                 modelId = "auto",
                 displayName = "Auto",
                 inputModalities = listOf(Modality.TEXT),
+                outputModalities = listOf(Modality.TEXT),
+                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+            )
+        )
+    ),
+    ProviderSetting.OpenAI(
+        id = DEFAULT_LOCAL_SAPI_PROVIDER_ID,
+        name = "SAPI Local",
+        baseUrl = DEFAULT_LOCAL_SAPI_PROVIDER_BASE_URL,
+        apiKey = "",
+        enabled = false,
+        builtIn = true,
+        description = {
+            Text("Local SAPI gateway on the host machine. Android emulator reaches host localhost through 10.0.2.2.")
+        },
+        shortDescription = {
+            Text("Local OpenAI-compatible SAPI gateway")
+        },
+        models = listOf(
+            Model(
+                id = Uuid.parse("dc9e32f8-8f07-4f14-915d-39ef78a58fc8"),
+                modelId = "auto",
+                displayName = "SAPI Auto",
+                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
                 outputModalities = listOf(Modality.TEXT),
                 abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
             )
@@ -272,4 +302,15 @@ val DEFAULT_PROVIDERS = listOf(
             )
         }
     ),
+)
+
+val DEFAULT_MCP_SERVERS = listOf(
+    McpServerConfig.StreamableHTTPServer(
+        id = DEFAULT_JSHOOK_MCP_SERVER_ID,
+        commonOptions = McpCommonOptions(
+            enable = true,
+            name = "jshookmcp",
+        ),
+        url = DEFAULT_JSHOOK_MCP_URL,
+    )
 )

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
@@ -29,11 +29,13 @@ import com.eterultimate.eteruee.data.ai.prompts.DEFAULT_SUGGESTION_PROMPT
 import com.eterultimate.eteruee.data.ai.prompts.DEFAULT_TITLE_PROMPT
 import com.eterultimate.eteruee.data.ai.prompts.DEFAULT_TRANSLATION_PROMPT
 import com.eterultimate.eteruee.data.ai.prompts.LEARNING_MODE_PROMPT
+import com.eterultimate.eteruee.data.ai.tools.LocalToolOption
 import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV1Migration
 import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV2Migration
 import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV3Migration
 import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV4Migration
 import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV5Migration
+import com.eterultimate.eteruee.data.datastore.migration.PreferenceStoreV6Migration
 import com.eterultimate.eteruee.data.model.Assistant
 import com.eterultimate.eteruee.data.model.Avatar
 import com.eterultimate.eteruee.data.model.InjectionPosition
@@ -66,6 +68,7 @@ private val Context.settingsStore by preferencesDataStore(
             PreferenceStoreV3Migration(),
             PreferenceStoreV4Migration(),
             PreferenceStoreV5Migration(),
+            PreferenceStoreV6Migration(),
         )
     }
 )
@@ -212,7 +215,7 @@ class SettingsStore(
                 searchServiceSelected = preferences[SEARCH_SELECTED] ?: 0,
                 mcpServers = preferences[MCP_SERVERS]?.let {
                     JsonInstant.decodeFromString(it)
-                } ?: emptyList(),
+                } ?: DEFAULT_MCP_SERVERS,
                 webDavConfig = preferences[WEBDAV_CONFIG]?.let {
                     JsonInstant.decodeFromString(it)
                 } ?: WebDavConfig(),
@@ -288,10 +291,17 @@ class SettingsStore(
                     ttsProviders.add(defaultTTSProvider.copyProvider())
                 }
             }
+            val mcpServers = it.mcpServers.ifEmpty { DEFAULT_MCP_SERVERS }.toMutableList()
+            DEFAULT_MCP_SERVERS.forEach { defaultMcpServer ->
+                if (mcpServers.none { server -> server.id == defaultMcpServer.id }) {
+                    mcpServers.add(defaultMcpServer.clone())
+                }
+            }
             it.copy(
                 providers = providers,
                 assistants = assistants,
-                ttsProviders = ttsProviders
+                ttsProviders = ttsProviders,
+                mcpServers = mcpServers,
             )
         }
         .map { settings ->
@@ -528,7 +538,7 @@ data class Settings(
     val searchServices: List<SearchServiceOptions> = listOf(SearchServiceOptions.DEFAULT),
     val searchCommonOptions: SearchCommonOptions = SearchCommonOptions(),
     val searchServiceSelected: Int = 0,
-    val mcpServers: List<McpServerConfig> = emptyList(),
+    val mcpServers: List<McpServerConfig> = DEFAULT_MCP_SERVERS,
     val webDavConfig: WebDavConfig = WebDavConfig(),
     val s3Config: S3Config = S3Config(),
     val postgresGatewayConfig: PostgresGatewayConfig = PostgresGatewayConfig(),
@@ -685,11 +695,19 @@ private fun Model.findModelProviderFromList(providers: List<ProviderSetting>): P
 }
 
 internal val DEFAULT_ASSISTANT_ID = Uuid.parse("0950e2dc-9bd5-4801-afa3-aa887aa36b4e")
+internal val DEFAULT_ASSISTANT_LOCAL_TOOLS = listOf(
+    LocalToolOption.TimeInfo,
+    LocalToolOption.Shell,
+    LocalToolOption.LinuxEnvironment,
+    LocalToolOption.DeviceAgent,
+)
 internal val DEFAULT_ASSISTANTS = listOf(
     Assistant(
         id = DEFAULT_ASSISTANT_ID,
         name = "",
-        systemPrompt = ""
+        systemPrompt = "",
+        mcpServers = setOf(DEFAULT_JSHOOK_MCP_SERVER_ID),
+        localTools = DEFAULT_ASSISTANT_LOCAL_TOOLS,
     ),
     Assistant(
         id = Uuid.parse("3d47790c-c415-4b90-9388-751128adb0a0"),

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/migration/PreferenceStoreV6Migration.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/migration/PreferenceStoreV6Migration.kt
@@ -1,0 +1,99 @@
+package com.eterultimate.eteruee.data.datastore.migration
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.preferences.core.Preferences
+import com.eterultimate.eteruee.data.datastore.DEFAULT_ASSISTANT_ID
+import com.eterultimate.eteruee.data.datastore.DEFAULT_JSHOOK_MCP_SERVER_ID
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.utils.JsonInstant
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+private const val DEFAULT_ASSISTANT_ID_TEXT = "0950e2dc-9bd5-4801-afa3-aa887aa36b4e"
+private const val DEFAULT_JSHOOK_MCP_SERVER_ID_TEXT = "27429a87-8db8-4f95-9f94-61ca3e82002e"
+
+private val DEFAULT_LOCAL_TOOL_TYPES = listOf(
+    "time_info",
+    "shell",
+    "linux_environment",
+    "device_agent",
+)
+
+class PreferenceStoreV6Migration : DataMigration<Preferences> {
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean {
+        val version = currentData[SettingsStore.VERSION]
+        return version == null || version < 6
+    }
+
+    override suspend fun migrate(currentData: Preferences): Preferences {
+        val prefs = currentData.toMutablePreferences()
+
+        prefs[SettingsStore.ASSISTANTS] = mergeDefaultAssistantRuntimeAccess(
+            prefs[SettingsStore.ASSISTANTS] ?: "[]",
+        )
+        prefs[SettingsStore.VERSION] = 6
+        return prefs.toPreferences()
+    }
+
+    override suspend fun cleanUp() {}
+}
+
+internal fun mergeDefaultAssistantRuntimeAccess(assistantsJson: String): String {
+    return runCatching {
+        val root = JsonInstant.parseToJsonElement(assistantsJson) as? JsonArray
+            ?: return@runCatching assistantsJson
+
+        val migrated = JsonArray(
+            root.map { assistant ->
+                val obj = assistant as? JsonObject ?: return@map assistant
+                val id = (obj["id"] as? JsonPrimitive)?.content
+                if (id != DEFAULT_ASSISTANT_ID.toString() && id != DEFAULT_ASSISTANT_ID_TEXT) {
+                    return@map assistant
+                }
+
+                val updated = obj.toMutableMap()
+                updated["mcpServers"] = mergeStringArray(
+                    existing = obj["mcpServers"],
+                    values = listOf(DEFAULT_JSHOOK_MCP_SERVER_ID.toString(), DEFAULT_JSHOOK_MCP_SERVER_ID_TEXT),
+                    distinctKey = { it },
+                )
+                updated["localTools"] = mergeLocalTools(obj["localTools"])
+                JsonObject(updated)
+            }
+        )
+
+        if (migrated == root) assistantsJson else JsonInstant.encodeToString(migrated)
+    }.getOrDefault(assistantsJson)
+}
+
+private fun mergeLocalTools(existing: JsonElement?): JsonArray {
+    val existingArray = existing as? JsonArray ?: JsonArray(emptyList())
+    val existingTypes = existingArray.mapNotNull(::localToolType).toSet()
+    val additions = DEFAULT_LOCAL_TOOL_TYPES
+        .filter { it !in existingTypes }
+        .map { JsonObject(mapOf("type" to JsonPrimitive(it))) }
+    return JsonArray(existingArray + additions)
+}
+
+private fun mergeStringArray(
+    existing: JsonElement?,
+    values: List<String>,
+    distinctKey: (String) -> String,
+): JsonArray {
+    val existingArray = existing as? JsonArray ?: JsonArray(emptyList())
+    val seen = existingArray
+        .mapNotNull { (it as? JsonPrimitive)?.content }
+        .map(distinctKey)
+        .toMutableSet()
+    val additions = values
+        .filter { seen.add(distinctKey(it)) }
+        .map { JsonPrimitive(it) }
+    return JsonArray(existingArray + additions)
+}
+
+private fun localToolType(element: JsonElement): String? {
+    val obj = element as? JsonObject ?: return null
+    return (obj["type"] as? JsonPrimitive)?.content
+}

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/migration/SettingsJsonMigrator.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/migration/SettingsJsonMigrator.kt
@@ -61,6 +61,12 @@ object SettingsJsonMigrator {
                 }
             }
 
+            // V4: 为内置默认助手补齐本地运行时能力和默认 jshook MCP
+            root["assistants"]?.let { element ->
+                val migrated = mergeDefaultAssistantRuntimeAccess(JsonInstant.encodeToString(element))
+                root["assistants"] = JsonInstant.parseToJsonElement(migrated)
+            }
+
             JsonInstant.encodeToString(JsonObject(root))
         }.onFailure {
             Log.e(TAG, "migrate: Failed to migrate settings JSON, using original", it)

--- a/app/src/main/java/com/eterultimate/eteruee/di/AppModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/di/AppModule.kt
@@ -13,6 +13,7 @@ import com.eterultimate.eteruee.data.ai.DynamicAISDK
 import com.eterultimate.eteruee.data.ai.tools.LocalTools
 import com.eterultimate.eteruee.data.event.AppEventBus
 import com.eterultimate.eteruee.device.DeviceAgentManager
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
 import com.eterultimate.eteruee.network.HiddifyCoreManager
 import com.eterultimate.eteruee.service.ChatService
 import com.eterultimate.eteruee.utils.EmojiData
@@ -45,7 +46,7 @@ val appModule = module {
     }
 
     single {
-        LocalTools(get(), get(), get(), get(), get(), get(), get(), get())
+        LocalTools(get(), get(), get(), get(), get(), get(), get(), get(), get())
     }
 
     single {
@@ -70,6 +71,10 @@ val appModule = module {
 
     single {
         DeviceAgentManager(get())
+    }
+
+    single {
+        LinuxEnvironmentManager(get(), get())
     }
 
     single {
@@ -127,6 +132,7 @@ val appModule = module {
             roleplayPresetService = get<RoleplayPresetService>(),
             localTools = get(),
             deviceAgentManager = get(),
+            linuxEnvironmentManager = get(),
         )
     }
 }

--- a/app/src/main/java/com/eterultimate/eteruee/linux/LinuxEnvironmentManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/linux/LinuxEnvironmentManager.kt
@@ -1,0 +1,707 @@
+package com.eterultimate.eteruee.linux
+
+import android.content.Context
+import android.os.Build
+import com.eterultimate.eteruee.shell.LocalShellRunner
+import com.github.luben.zstd.ZstdInputStream
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.commons.compress.archivers.ar.ArArchiveInputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
+
+private const val EXECUTOR_NAME = "eteruee-archlinux-proot"
+private const val INSTALL_EXECUTOR_NAME = "eteruee-archlinux-installer"
+private const val DEFAULT_TIMEOUT_SECONDS = 60
+private const val MAX_TIMEOUT_SECONDS = 600
+private const val INSTALL_SCRIPT_NAME = "install-archlinux.sh"
+private const val MAX_ROOTFS_ENTRY_BYTES = 512L * 1024 * 1024
+private const val MAX_TERMUX_PACKAGE_ENTRY_BYTES = 64L * 1024 * 1024
+private const val TERMUX_PREFIX_PATH = "data/data/com.termux/files/usr/"
+private const val TERMUX_REPO_BASE_URL = "https://packages.termux.dev/apt/termux-main/"
+
+private val ARCH_ROOTFS_SOURCES = mapOf(
+    "arm64-v8a" to RootfsSource(
+        url = "https://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz",
+        fileName = "ArchLinuxARM-aarch64-latest.tar.gz",
+        compression = RootfsCompression.Gzip,
+        stripFirstPathSegment = false,
+    ),
+    "armeabi-v7a" to RootfsSource(
+        url = "https://os.archlinuxarm.org/os/ArchLinuxARM-armv7-latest.tar.gz",
+        fileName = "ArchLinuxARM-armv7-latest.tar.gz",
+        compression = RootfsCompression.Gzip,
+        stripFirstPathSegment = false,
+    ),
+    "x86_64" to RootfsSource(
+        url = "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.zst",
+        fileName = "archlinux-bootstrap-x86_64.tar.zst",
+        compression = RootfsCompression.Zstd,
+        stripFirstPathSegment = true,
+    ),
+)
+
+private val TERMUX_BOOTSTRAP_PACKAGES = mapOf(
+    "arm64-v8a" to listOf(
+        TermuxPackageSource(
+            fileName = "proot_5.1.107.78-1_aarch64.deb",
+            path = "pool/main/p/proot/proot_5.1.107.78-1_aarch64.deb",
+            sha256 = "f703888191e7a1aade19882a36236507a39796c7e7016c57ed2aedd309b1a2c6",
+        ),
+        TermuxPackageSource(
+            fileName = "libandroid-shmem_0.7_aarch64.deb",
+            path = "pool/main/liba/libandroid-shmem/libandroid-shmem_0.7_aarch64.deb",
+            sha256 = "0da3a24d558b93c92bcf8d611e0826a99ff96e396b148e6cdf33b47c47c57ff6",
+        ),
+        TermuxPackageSource(
+            fileName = "libtalloc_2.4.3_aarch64.deb",
+            path = "pool/main/libt/libtalloc/libtalloc_2.4.3_aarch64.deb",
+            sha256 = "ac81ad623d74c209718b9f3acb2dd702cc8a88c431e820d212229910b4db29da",
+        ),
+    ),
+    "armeabi-v7a" to listOf(
+        TermuxPackageSource(
+            fileName = "proot_5.1.107.78-1_arm.deb",
+            path = "pool/main/p/proot/proot_5.1.107.78-1_arm.deb",
+            sha256 = "7b8757fea6fa66dcd1964058329d92cc271936c6070c283f37455f4c7fc79ade",
+        ),
+        TermuxPackageSource(
+            fileName = "libandroid-shmem_0.7_arm.deb",
+            path = "pool/main/liba/libandroid-shmem/libandroid-shmem_0.7_arm.deb",
+            sha256 = "5832fd11dca9be2a288dd8fbc2b2799b289c812c7a8764f1f8234c425aa64ce5",
+        ),
+        TermuxPackageSource(
+            fileName = "libtalloc_2.4.3_arm.deb",
+            path = "pool/main/libt/libtalloc/libtalloc_2.4.3_arm.deb",
+            sha256 = "cd56f87007e487c8025fac2df2a27b2bc58102344040a527eaa6fa7527d18f9b",
+        ),
+    ),
+    "x86_64" to listOf(
+        TermuxPackageSource(
+            fileName = "proot_5.1.107.78-1_x86_64.deb",
+            path = "pool/main/p/proot/proot_5.1.107.78-1_x86_64.deb",
+            sha256 = "5c1ac8b10a1e188dbce3f9406075f1970dc5ac152cd4acb389f57406ec90390c",
+        ),
+        TermuxPackageSource(
+            fileName = "libandroid-shmem_0.7_x86_64.deb",
+            path = "pool/main/liba/libandroid-shmem/libandroid-shmem_0.7_x86_64.deb",
+            sha256 = "ffa9e4c87467b158b148d0ff92dda796aa038276c2075af3269cdcdb06f25797",
+        ),
+        TermuxPackageSource(
+            fileName = "libtalloc_2.4.3_x86_64.deb",
+            path = "pool/main/libt/libtalloc/libtalloc_2.4.3_x86_64.deb",
+            sha256 = "7ca2eaae2e53b28228a01301bc410b62845403d6317c25b8e0a7f40681de0628",
+        ),
+    ),
+)
+
+class LinuxEnvironmentManager(
+    private val context: Context,
+    private val okHttpClient: OkHttpClient,
+) {
+    private val executor = Executors.newCachedThreadPool()
+
+    private val baseDir: File
+        get() = File(context.filesDir, "linux")
+
+    private val downloadDir: File
+        get() = File(baseDir, "downloads")
+
+    val rootfsDir: File
+        get() = File(baseDir, "archlinux")
+
+    val binDir: File
+        get() = File(baseDir, "bin")
+
+    val prootBinary: File
+        get() = File(termuxUsrDir, "bin/proot")
+
+    val termuxUsrDir: File
+        get() = File(baseDir, "usr")
+
+    val installScript: File
+        get() = File(baseDir, INSTALL_SCRIPT_NAME)
+
+    fun getStatus(): LinuxEnvironmentStatus {
+        val primaryAbi = primaryAbi()
+        val rootfsSource = rootfsSourceForAbi(primaryAbi)
+        val termuxPackages = termuxPackagesForAbi(primaryAbi)
+        val rootfsInstalled = isRootfsInstalled()
+        val prootExecutable = prootBinary.canExecute()
+        val shellRunner = resolveRunner()
+        return LinuxEnvironmentStatus(
+            installed = rootfsInstalled,
+            rootfsPath = rootfsDir.absolutePath,
+            termuxUsrPath = termuxUsrDir.absolutePath,
+            prootPath = prootBinary.absolutePath,
+            prootExecutable = prootExecutable,
+            installScriptPath = installScript.absolutePath,
+            rootfsArchivePath = rootfsSource?.let { File(downloadDir, it.fileName).absolutePath },
+            primaryAbi = primaryAbi,
+            supportedRootfsUrl = rootfsSource?.url,
+            termuxPackageUrls = termuxPackages.map { it.url },
+            runner = shellRunner,
+            canExecuteLinux = shellRunner != null,
+            message = when {
+                shellRunner != null -> "Arch Linux runner is ready"
+                rootfsSource == null -> "Unsupported Android ABI for Arch Linux bootstrap: $primaryAbi"
+                !rootfsInstalled -> "Arch Linux rootfs is not installed"
+                !prootBinary.exists() -> "proot binary is missing"
+                !prootExecutable -> "proot binary is not executable"
+                else -> "Arch Linux runner is not ready"
+            },
+        )
+    }
+
+    suspend fun prepareInstallerScript(): LinuxEnvironmentStatus = withContext(Dispatchers.IO) {
+        baseDir.mkdirs()
+        binDir.mkdirs()
+        termuxUsrDir.mkdirs()
+        downloadDir.mkdirs()
+        installScript.writeText(buildInstallScript(), Charsets.UTF_8)
+        installScript.setExecutable(true, false)
+        getStatus().copy(message = "Arch Linux installer script prepared")
+    }
+
+    suspend fun install(timeoutSeconds: Int = MAX_TIMEOUT_SECONDS): LinuxCommandResult = withContext(Dispatchers.IO) {
+        val timeout = timeoutSeconds.coerceIn(1, MAX_TIMEOUT_SECONDS)
+        val installLog = StringBuilder()
+        prepareInstallerScript()
+
+        val initialStatus = getStatus()
+        if (initialStatus.supportedRootfsUrl == null) {
+            return@withContext initialStatus.toInstallResult(
+                command = "linux.install",
+                stdout = "",
+                stderr = initialStatus.message,
+                exitCode = 2,
+            )
+        }
+
+        try {
+            installTermuxBootstrapPackages(installLog)
+            val source = requireNotNull(rootfsSourceForAbi(primaryAbi()))
+            val archive = downloadRootfsIfNeeded(source, installLog)
+            if (!isRootfsInstalled()) {
+                extractRootfs(source, archive, installLog)
+            } else {
+                installLog.appendLine("Rootfs already installed at ${rootfsDir.absolutePath}")
+            }
+        } catch (error: Throwable) {
+            return@withContext getStatus().toInstallResult(
+                command = "linux.install",
+                stdout = installLog.toString(),
+                stderr = error.message ?: error.javaClass.simpleName,
+                exitCode = 1,
+            )
+        }
+
+        val status = getStatus()
+        if (!status.canExecuteLinux) {
+            return@withContext status.toInstallResult(
+                command = "linux.install",
+                stdout = installLog.toString(),
+                stderr = status.message,
+                exitCode = 3,
+            )
+        }
+
+        val verify = execute(
+            command = "printf 'Arch Linux ready: '; head -n 1 /etc/os-release",
+            timeoutSeconds = timeout,
+        )
+        verify.copy(
+            stdout = installLog.append(verify.stdout).toString(),
+            executor = INSTALL_EXECUTOR_NAME,
+            command = "linux.install",
+        )
+    }
+
+    suspend fun execute(
+        command: String,
+        workingDir: String? = null,
+        stdin: String? = null,
+        timeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS,
+    ): LinuxCommandResult = withContext(Dispatchers.IO) {
+        require(command.isNotBlank()) { "command is required" }
+        val runner = resolveRunner()
+            ?: return@withContext LinuxCommandResult(
+                stdout = "",
+                stderr = getStatus().message,
+                exitCode = -1,
+                executor = EXECUTOR_NAME,
+                shell = "bash",
+                workingDir = workingDir?.takeIf { it.isNotBlank() } ?: "/root",
+                command = command,
+                rootfsPath = rootfsDir.absolutePath,
+                prootPath = prootBinary.absolutePath,
+                fallback = true,
+            )
+
+        val timeout = timeoutSeconds.coerceIn(1, MAX_TIMEOUT_SECONDS).toLong()
+        val linuxWorkingDir = workingDir?.takeIf { it.isNotBlank() } ?: "/root"
+        val process = ProcessBuilder(
+            runner,
+            "-0",
+            "-r",
+            rootfsDir.absolutePath,
+            "-b",
+            "/dev",
+            "-b",
+            "/proc",
+            "-b",
+            "/sys",
+            "-b",
+            "${LocalShellRunner.defaultWorkingDir(context).absolutePath}:/mnt/eteruee",
+            "-w",
+            linuxWorkingDir,
+            "/usr/bin/env",
+            "-i",
+            "HOME=/root",
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
+            "TERM=xterm-256color",
+            "LANG=C.UTF-8",
+            "/bin/bash",
+            "-lc",
+            command,
+        )
+            .directory(baseDir)
+            .apply {
+                environment().putAll(linuxRunnerEnvironment())
+            }
+            .start()
+
+        if (stdin != null) {
+            process.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
+                writer.write(stdin)
+            }
+        } else {
+            process.outputStream.close()
+        }
+
+        val stdoutFuture = executor.submit(Callable {
+            process.inputStream.bufferedReader(Charsets.UTF_8).readText()
+        })
+        val stderrFuture = executor.submit(Callable {
+            process.errorStream.bufferedReader(Charsets.UTF_8).readText()
+        })
+
+        val completed = process.waitFor(timeout, TimeUnit.SECONDS)
+        if (!completed) {
+            process.destroyForcibly()
+        }
+
+        val stdout = runCatching { stdoutFuture.get(1, TimeUnit.SECONDS) }.getOrDefault("")
+        val stderr = runCatching { stderrFuture.get(1, TimeUnit.SECONDS) }.getOrDefault("")
+        LinuxCommandResult(
+            stdout = stdout,
+            stderr = if (completed) stderr else stderr + "\n[TIMEOUT] Command timed out after ${timeout}s",
+            exitCode = if (completed) process.exitValue() else -1,
+            executor = EXECUTOR_NAME,
+            shell = "/bin/bash",
+            workingDir = linuxWorkingDir,
+            command = command,
+            rootfsPath = rootfsDir.absolutePath,
+            prootPath = runner,
+            fallback = false,
+        )
+    }
+
+    private fun installTermuxBootstrapPackages(log: StringBuilder) {
+        val packages = termuxPackagesForAbi(primaryAbi())
+        if (packages.isEmpty()) return
+        if (prootBinary.isFile && prootBinary.canExecute() && termuxUsrDir.resolve("lib/libtalloc.so").isFile) {
+            log.appendLine("Termux proot runtime already installed at ${termuxUsrDir.absolutePath}")
+            return
+        }
+
+        termuxUsrDir.mkdirs()
+        packages.forEach { source ->
+            val archive = downloadPackageIfNeeded(source, log)
+            extractTermuxPackage(archive, log)
+        }
+        prootBinary.setExecutable(true, true)
+        termuxUsrDir.resolve("libexec/proot/loader").setExecutable(true, true)
+        termuxUsrDir.resolve("libexec/proot/loader32").setExecutable(true, true)
+        log.appendLine("Termux proot runtime installed at ${termuxUsrDir.absolutePath}")
+    }
+
+    private fun downloadRootfsIfNeeded(source: RootfsSource, log: StringBuilder): File {
+        downloadDir.mkdirs()
+        val archive = File(downloadDir, source.fileName)
+        if (archive.isFile && archive.length() > 0) {
+            log.appendLine("Rootfs archive already downloaded at ${archive.absolutePath}")
+            return archive
+        }
+
+        downloadFile(
+            url = source.url,
+            target = archive,
+            log = log,
+            label = "Arch Linux rootfs",
+        )
+        return archive
+    }
+
+    private fun downloadPackageIfNeeded(source: TermuxPackageSource, log: StringBuilder): File {
+        val archive = File(downloadDir, source.fileName)
+        if (archive.isFile && archive.length() > 0) {
+            verifySha256(archive, source.sha256)
+            log.appendLine("Termux package already downloaded at ${archive.absolutePath}")
+            return archive
+        }
+
+        downloadFile(
+            url = source.url,
+            target = archive,
+            log = log,
+            label = "Termux package",
+        )
+        verifySha256(archive, source.sha256)
+        return archive
+    }
+
+    private fun downloadFile(
+        url: String,
+        target: File,
+        log: StringBuilder,
+        label: String,
+    ) {
+        downloadDir.mkdirs()
+        val tmp = File(downloadDir, "${target.name}.part")
+        if (tmp.exists()) tmp.delete()
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+        log.appendLine("Downloading $url")
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                error("Failed to download $label: HTTP ${response.code}")
+            }
+            val body = response.body
+            tmp.outputStream().use { output ->
+                body.byteStream().copyTo(output)
+            }
+        }
+        if (tmp.length() <= 0) {
+            tmp.delete()
+            error("Downloaded $label is empty")
+        }
+        if (target.exists()) target.delete()
+        if (!tmp.renameTo(target)) {
+            tmp.copyTo(target, overwrite = true)
+            tmp.delete()
+        }
+        log.appendLine("Downloaded $label to ${target.absolutePath}")
+    }
+
+    private fun extractRootfs(source: RootfsSource, archive: File, log: StringBuilder) {
+        val canonicalRoot = rootfsDir.canonicalFile
+        if (canonicalRoot.exists()) {
+            canonicalRoot.deleteRecursively()
+        }
+        canonicalRoot.mkdirs()
+        log.appendLine("Extracting rootfs to ${canonicalRoot.absolutePath}")
+
+        rootfsArchiveStream(source, archive).use { input ->
+            TarArchiveInputStream(input).use { tar ->
+                while (true) {
+                    val entry = tar.nextEntry ?: break
+                    if (!tar.canReadEntryData(entry)) continue
+
+                    val relativeName = sanitizeTarEntryName(entry.name, source.stripFirstPathSegment)
+                        ?: continue
+                    val target = File(canonicalRoot, relativeName).canonicalFile
+                    if (!target.path.startsWith(canonicalRoot.path + File.separator)) {
+                        error("Refusing to extract path outside rootfs: ${entry.name}")
+                    }
+
+                    when {
+                        entry.isDirectory -> target.mkdirs()
+                        entry.isSymbolicLink -> {
+                            target.parentFile?.mkdirs()
+                            runCatching {
+                                java.nio.file.Files.createSymbolicLink(target.toPath(), java.nio.file.Path.of(entry.linkName))
+                            }.onFailure {
+                                File(target.parentFile, "${target.name}.symlink").writeText(entry.linkName, Charsets.UTF_8)
+                            }
+                        }
+                        entry.isLink -> Unit
+                        else -> {
+                            if (entry.size > MAX_ROOTFS_ENTRY_BYTES) {
+                                error("Refusing oversized rootfs entry: ${entry.name}")
+                            }
+                            target.parentFile?.mkdirs()
+                            target.outputStream().use { output ->
+                                tar.copyTo(output)
+                            }
+                            if ((entry.mode and 0b001_001_001) != 0) {
+                                target.setExecutable(true, false)
+                            }
+                        }
+                    }
+                    if (!entry.isSymbolicLink && !entry.isLink) {
+                        target.setReadable(true, false)
+                        target.setWritable(true, true)
+                    }
+                }
+            }
+        }
+
+        if (!isRootfsInstalled()) {
+            error("Arch Linux rootfs extraction finished but etc/os-release was not found")
+        }
+        log.appendLine("Rootfs extraction complete")
+    }
+
+    private fun extractTermuxPackage(archive: File, log: StringBuilder) {
+        archive.inputStream().buffered().use { fileInput ->
+            ArArchiveInputStream(fileInput).use { ar ->
+                while (true) {
+                    val entry = ar.nextEntry ?: break
+                    if (entry.name != "data.tar.xz") continue
+                    XZCompressorInputStream(ar).use { xz ->
+                        extractTermuxDataTar(xz)
+                    }
+                    log.appendLine("Extracted Termux package ${archive.name}")
+                    return
+                }
+            }
+        }
+        error("Termux package does not contain data.tar.xz: ${archive.name}")
+    }
+
+    private fun extractTermuxDataTar(input: InputStream) {
+        val canonicalRoot = termuxUsrDir.canonicalFile
+        canonicalRoot.mkdirs()
+        TarArchiveInputStream(input).use { tar ->
+            while (true) {
+                val entry = tar.nextEntry ?: break
+                if (!tar.canReadEntryData(entry)) continue
+
+                val relativeName = sanitizeTermuxPackageEntryName(entry.name) ?: continue
+                val target = File(canonicalRoot, relativeName).canonicalFile
+                if (!target.path.startsWith(canonicalRoot.path + File.separator)) {
+                    error("Refusing to extract path outside Termux runtime: ${entry.name}")
+                }
+
+                when {
+                    entry.isDirectory -> target.mkdirs()
+                    entry.isSymbolicLink -> {
+                        target.parentFile?.mkdirs()
+                        runCatching {
+                            java.nio.file.Files.createSymbolicLink(target.toPath(), java.nio.file.Path.of(entry.linkName))
+                        }.onFailure {
+                            File(target.parentFile, "${target.name}.symlink").writeText(entry.linkName, Charsets.UTF_8)
+                        }
+                    }
+                    entry.isLink -> Unit
+                    else -> {
+                        if (entry.size > MAX_TERMUX_PACKAGE_ENTRY_BYTES) {
+                            error("Refusing oversized Termux package entry: ${entry.name}")
+                        }
+                        target.parentFile?.mkdirs()
+                        target.outputStream().use { output ->
+                            tar.copyTo(output)
+                        }
+                        if ((entry.mode and 0b001_001_001) != 0) {
+                            target.setExecutable(true, true)
+                        }
+                    }
+                }
+                if (!entry.isSymbolicLink && !entry.isLink) {
+                    target.setReadable(true, true)
+                    target.setWritable(true, true)
+                }
+            }
+        }
+    }
+
+    private fun rootfsArchiveStream(source: RootfsSource, archive: File): InputStream {
+        val input = BufferedInputStream(FileInputStream(archive))
+        return when (source.compression) {
+            RootfsCompression.Gzip -> GZIPInputStream(input)
+            RootfsCompression.Zstd -> ZstdInputStream(input)
+        }
+    }
+
+    private fun sanitizeTarEntryName(name: String, stripFirstPathSegment: Boolean): String? {
+        val normalized = name.replace('\\', '/').trimStart('/')
+        val parts = normalized.split('/')
+            .filter { it.isNotEmpty() && it != "." }
+            .drop(if (stripFirstPathSegment) 1 else 0)
+        if (parts.isEmpty() || parts.any { it == ".." }) return null
+        return parts.joinToString(File.separator)
+    }
+
+    private fun sanitizeTermuxPackageEntryName(name: String): String? {
+        val normalized = name.replace('\\', '/').trimStart('.', '/')
+        if (!normalized.startsWith(TERMUX_PREFIX_PATH)) return null
+        val relative = normalized.removePrefix(TERMUX_PREFIX_PATH)
+        val parts = relative.split('/')
+            .filter { it.isNotEmpty() && it != "." }
+        if (parts.isEmpty() || parts.any { it == ".." }) return null
+        return parts.joinToString(File.separator)
+    }
+
+    private fun resolveRunner(): String? =
+        prootBinary
+            .takeIf { isRootfsInstalled() && it.isFile && it.canExecute() }
+            ?.absolutePath
+
+    private fun linuxRunnerEnvironment(): Map<String, String> {
+        val usr = termuxUsrDir.absolutePath
+        return LocalShellRunner.defaultEnvironment(context) + mapOf(
+            "PATH" to "$usr/bin:/system/bin:/system/xbin",
+            "LD_LIBRARY_PATH" to "$usr/lib",
+            "PROOT_LOADER" to "$usr/libexec/proot/loader",
+            "PROOT_TMP_DIR" to context.cacheDir.absolutePath,
+        )
+    }
+
+    private fun isRootfsInstalled(): Boolean =
+        rootfsDir.resolve("etc/os-release").isFile
+
+    private fun primaryAbi(): String =
+        Build.SUPPORTED_ABIS.firstOrNull().orEmpty()
+
+    private fun rootfsSourceForAbi(abi: String): RootfsSource? =
+        ARCH_ROOTFS_SOURCES[abi.lowercase(Locale.ROOT)]
+
+    private fun termuxPackagesForAbi(abi: String): List<TermuxPackageSource> =
+        TERMUX_BOOTSTRAP_PACKAGES[abi.lowercase(Locale.ROOT)].orEmpty()
+
+    private fun verifySha256(file: File, expected: String) {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        val actual = digest.digest().joinToString("") { "%02x".format(it) }
+        check(actual.equals(expected, ignoreCase = true)) {
+            "SHA-256 mismatch for ${file.name}: expected $expected, got $actual"
+        }
+    }
+
+    private fun buildInstallScript(): String {
+        val primaryAbi = primaryAbi()
+        val rootfsSource = rootfsSourceForAbi(primaryAbi)
+        return """
+            #!/system/bin/sh
+            set -eu
+
+            ROOTFS_DIR="${rootfsDir.absolutePath}"
+            PROOT="${prootBinary.absolutePath}"
+
+            cat <<'EOF'
+            EterUee installs Arch Linux from app code, not this shell script.
+            Rootfs URL: ${rootfsSource?.url ?: "unsupported ABI: $primaryAbi"}
+            Rootfs path: ${rootfsDir.absolutePath}
+            proot path: ${prootBinary.absolutePath}
+            Termux runtime path: ${termuxUsrDir.absolutePath}
+
+            Call linux_environment/install from EterUee to install proot and rootfs.
+            EOF
+
+            if [ ! -f "${'$'}ROOTFS_DIR/etc/os-release" ]; then
+              echo "Rootfs is not installed yet; use EterUee's Linux installer API." >&2
+              exit 4
+            fi
+            if [ ! -x "${'$'}PROOT" ]; then
+              echo "Missing executable proot binary at ${'$'}PROOT" >&2
+              exit 3
+            fi
+            export LD_LIBRARY_PATH="${termuxUsrDir.absolutePath}/lib"
+            export PROOT_LOADER="${termuxUsrDir.absolutePath}/libexec/proot/loader"
+            "${'$'}PROOT" -0 -r "${'$'}ROOTFS_DIR" -b /dev -b /proc -b /sys -w /root /bin/sh -lc 'printf "Arch Linux ready: "; head -n 1 /etc/os-release'
+        """.trimIndent()
+    }
+}
+
+private fun LinuxEnvironmentStatus.toInstallResult(
+    command: String,
+    stdout: String,
+    stderr: String,
+    exitCode: Int,
+): LinuxCommandResult = LinuxCommandResult(
+    stdout = stdout,
+    stderr = stderr,
+    exitCode = exitCode,
+    executor = INSTALL_EXECUTOR_NAME,
+    shell = "kotlin",
+    workingDir = rootfsPath,
+    command = command,
+    rootfsPath = rootfsPath,
+    prootPath = prootPath,
+    fallback = true,
+)
+
+private data class RootfsSource(
+    val url: String,
+    val fileName: String,
+    val compression: RootfsCompression,
+    val stripFirstPathSegment: Boolean,
+)
+
+private data class TermuxPackageSource(
+    val fileName: String,
+    val path: String,
+    val sha256: String,
+) {
+    val url: String
+        get() = TERMUX_REPO_BASE_URL + path
+}
+
+private enum class RootfsCompression {
+    Gzip,
+    Zstd,
+}
+
+@Serializable
+data class LinuxEnvironmentStatus(
+    val installed: Boolean,
+    val rootfsPath: String,
+    val termuxUsrPath: String,
+    val prootPath: String,
+    val prootExecutable: Boolean,
+    val installScriptPath: String,
+    val rootfsArchivePath: String? = null,
+    val primaryAbi: String,
+    val supportedRootfsUrl: String? = null,
+    val termuxPackageUrls: List<String> = emptyList(),
+    val runner: String? = null,
+    val canExecuteLinux: Boolean,
+    val message: String,
+)
+
+@Serializable
+data class LinuxCommandResult(
+    val stdout: String,
+    val stderr: String,
+    val exitCode: Int,
+    val executor: String,
+    val shell: String,
+    val workingDir: String,
+    val command: String,
+    val rootfsPath: String,
+    val prootPath: String,
+    val fallback: Boolean,
+)

--- a/app/src/main/java/com/eterultimate/eteruee/plugin/AppCapabilityRegistry.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/plugin/AppCapabilityRegistry.kt
@@ -1,0 +1,19 @@
+package com.eterultimate.eteruee.plugin
+
+class AppCapabilityRegistry(
+    capabilities: List<AppCapability>,
+) {
+    private val byId: Map<String, AppCapability> = capabilities.associateBy { it.id }
+
+    fun list(): List<AppCapabilityDescriptor> =
+        byId.values.sortedBy { it.id }.map { it.toDescriptor() }
+
+    suspend fun execute(method: String, input: kotlinx.serialization.json.JsonObject, context: PluginCallContext) =
+        get(method).run {
+            context.requirePermissions(permissions)
+            execute(input, context)
+        }
+
+    fun get(id: String): AppCapability =
+        byId[id] ?: throw PluginProtocolException("METHOD_NOT_FOUND", "Unknown capability: $id")
+}

--- a/app/src/main/java/com/eterultimate/eteruee/plugin/BuiltInAppCapabilities.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/plugin/BuiltInAppCapabilities.kt
@@ -1,0 +1,625 @@
+package com.eterultimate.eteruee.plugin
+
+import android.content.Context
+import androidx.core.net.toUri
+import com.eterultimate.eteruee.BuildConfig
+import com.eterultimate.eteruee.ai.ui.UIMessagePart
+import com.eterultimate.eteruee.data.ai.tools.LocalTools
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.datastore.getCurrentAssistant
+import com.eterultimate.eteruee.data.files.FilesManager
+import com.eterultimate.eteruee.data.model.Assistant
+import com.eterultimate.eteruee.data.repository.ConversationRepository
+import com.eterultimate.eteruee.device.DeviceAgentManager
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
+import com.eterultimate.eteruee.service.ChatService
+import com.eterultimate.eteruee.utils.JsonInstant
+import com.eterultimate.eteruee.web.BadRequestException
+import com.eterultimate.eteruee.web.NotFoundException
+import com.eterultimate.eteruee.web.dto.PagedResult
+import com.eterultimate.eteruee.web.dto.toDto
+import com.eterultimate.eteruee.web.dto.toListDto
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.put
+
+private const val MAX_FILE_READ_BYTES = 1 * 1024 * 1024
+private val SAFE_TOOL_CALLS = setOf("get_time_info")
+
+fun createBuiltInAppCapabilityRegistry(
+    context: Context,
+    settingsStore: SettingsStore,
+    conversationRepo: ConversationRepository,
+    chatService: ChatService,
+    filesManager: FilesManager,
+    localTools: LocalTools,
+    deviceAgentManager: DeviceAgentManager,
+    linuxEnvironmentManager: LinuxEnvironmentManager,
+): AppCapabilityRegistry = AppCapabilityRegistry(
+    listOf(
+        AppInfoCapability(),
+        SettingsGetCapability(settingsStore),
+        AssistantListCapability(settingsStore),
+        ConversationListCapability(settingsStore, conversationRepo, chatService),
+        ConversationGetCapability(settingsStore, conversationRepo, chatService),
+        ChatSendCapability(settingsStore, conversationRepo, chatService),
+        FilesGetCapability(context, filesManager),
+        ToolsListCapability(settingsStore, localTools),
+        ToolsCallCapability(settingsStore, localTools),
+        DeviceStatusCapability(deviceAgentManager),
+        DeviceShizukuRequestPermissionCapability(deviceAgentManager),
+        DeviceAdbShellCapability(deviceAgentManager),
+        LinuxStatusCapability(linuxEnvironmentManager),
+        LinuxPrepareCapability(linuxEnvironmentManager),
+        LinuxInstallCapability(linuxEnvironmentManager),
+        LinuxShellCapability(linuxEnvironmentManager),
+    )
+)
+
+fun defaultPluginPermissions(): Set<PluginPermission> = setOf(
+    PluginPermission.ConversationRead,
+    PluginPermission.AssistantRead,
+    PluginPermission.SettingsRead,
+    PluginPermission.FilesRead,
+    PluginPermission.ToolsRead,
+    PluginPermission.ToolsExecute,
+    PluginPermission.DeviceRead,
+)
+
+class AppInfoCapability : AppCapability {
+    override val id = "app.info"
+    override val description = "Return application and plugin gateway metadata."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = emptySet<PluginPermission>()
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement = buildJsonObject {
+        put("name", "EterUee")
+        put("versionName", BuildConfig.VERSION_NAME)
+        put("versionCode", BuildConfig.VERSION_CODE)
+        put("pluginGateway", buildJsonObject {
+            put("protocol", "eteruee-plugin-rpc")
+            put("version", 1)
+            put("capabilityMode", "external-websocket")
+        })
+    }
+}
+
+class SettingsGetCapability(
+    private val settingsStore: SettingsStore,
+) : AppCapability {
+    override val id = "settings.get"
+    override val description = "Return a redacted summary of app settings relevant to plugins."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.SettingsRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val settings = settingsStore.settingsFlow.first()
+        val currentAssistant = settings.getCurrentAssistant()
+        return buildJsonObject {
+            put("currentAssistantId", settings.assistantId.toString())
+            put("currentAssistantName", currentAssistant.name)
+            put("assistantCount", settings.assistants.size)
+            put("mcpServerCount", settings.mcpServers.size)
+            put("webServer", buildJsonObject {
+                put("enabled", settings.webServerEnabled)
+                put("port", settings.webServerPort)
+                put("jwtEnabled", settings.webServerJwtEnabled)
+                put("localhostOnly", settings.webServerLocalhostOnly)
+            })
+            put("features", buildJsonObject {
+                put("webSearch", settings.enableWebSearch)
+                put("subagent", settings.enableSubagent)
+                put("developerMode", settings.developerMode)
+            })
+        }
+    }
+}
+
+class AssistantListCapability(
+    private val settingsStore: SettingsStore,
+) : AppCapability {
+    override val id = "assistant.list"
+    override val description = "List assistants with non-secret metadata and enabled extension handles."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.AssistantRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val settings = settingsStore.settingsFlow.first()
+        return buildJsonObject {
+            put("currentAssistantId", settings.assistantId.toString())
+            put(
+                "items",
+                JsonArray(settings.assistants.map { assistant ->
+                    assistant.toPluginJson(isCurrent = assistant.id == settings.assistantId)
+                })
+            )
+        }
+    }
+}
+
+class ConversationListCapability(
+    private val settingsStore: SettingsStore,
+    private val conversationRepo: ConversationRepository,
+    private val chatService: ChatService,
+) : AppCapability {
+    override val id = "conversation.list"
+    override val description = "List conversations for the current assistant with pagination."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("offset", integerSchema("Zero-based paging offset."))
+            put("limit", integerSchema("Page size from 1 to 100. Defaults to 20."))
+            put("query", stringSchema("Optional title search query."))
+        }
+    )
+    override val permissions = setOf(PluginPermission.ConversationRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val offset = input.optionalInt("offset") ?: 0
+        val limit = input.optionalInt("limit") ?: 20
+        val query = input.optionalString("query").orEmpty().trim()
+        require(offset >= 0) { "offset must be >= 0" }
+        require(limit in 1..100) { "limit must be in 1..100" }
+
+        val settings = settingsStore.settingsFlow.first()
+        val page = if (query.isBlank()) {
+            conversationRepo.getConversationsOfAssistantPage(settings.assistantId, offset, limit)
+        } else {
+            conversationRepo.searchConversationsOfAssistantPage(settings.assistantId, query, offset, limit)
+        }
+        val generationJobs = chatService.getConversationJobs().first()
+        return JsonInstant.encodeToJsonElement(
+            PagedResult(
+                items = page.items.map { conversation ->
+                    conversation.toListDto(isGenerating = generationJobs[conversation.id] != null)
+                },
+                nextOffset = page.nextOffset
+            )
+        )
+    }
+}
+
+class ConversationGetCapability(
+    private val settingsStore: SettingsStore,
+    private val conversationRepo: ConversationRepository,
+    private val chatService: ChatService,
+) : AppCapability {
+    override val id = "conversation.get"
+    override val description = "Read one conversation from the current assistant."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("id", stringSchema("Conversation UUID."))
+        },
+        required = listOf("id")
+    )
+    override val permissions = setOf(PluginPermission.ConversationRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val id = input.requiredUuid("id")
+        val settings = settingsStore.settingsFlow.first()
+        val conversation = conversationRepo.getConversationById(id)
+            ?: throw NotFoundException("Conversation not found")
+        if (conversation.assistantId != settings.assistantId) {
+            throw NotFoundException("Conversation not found")
+        }
+        val isGenerating = chatService.getGenerationJobStateFlow(id).first() != null
+        return JsonInstant.encodeToJsonElement(conversation.toDto(isGenerating))
+    }
+}
+
+class ChatSendCapability(
+    private val settingsStore: SettingsStore,
+    private val conversationRepo: ConversationRepository,
+    private val chatService: ChatService,
+) : AppCapability {
+    override val id = "chat.send"
+    override val description = "Append a user message to a conversation and optionally start generation."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("conversationId", stringSchema("Optional conversation UUID. A new UUID is created when omitted."))
+            put("text", stringSchema("User text to send."))
+            put("parts", arraySchema("Optional UIMessagePart array. Used when text is omitted."))
+            put("answer", booleanSchema("Whether to start assistant generation. Defaults to true."))
+        }
+    )
+    override val permissions = setOf(PluginPermission.ConversationWrite)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val conversationId = input.optionalString("conversationId")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { parseUuid(it, "conversationId") }
+            ?: Uuid.random()
+        val answer = input.optionalBoolean("answer") ?: true
+        val parts = input.toMessageParts()
+        if (parts.isEmpty()) {
+            throw BadRequestException("chat.send requires text or parts")
+        }
+
+        val existing = conversationRepo.getConversationById(conversationId)
+        if (existing != null) {
+            val currentAssistantId = settingsStore.settingsFlow.first().assistantId
+            if (existing.assistantId != currentAssistantId) {
+                throw NotFoundException("Conversation not found")
+            }
+        }
+
+        chatService.initializeConversation(conversationId)
+        chatService.sendMessage(conversationId, parts, answer = answer)
+
+        return buildJsonObject {
+            put("conversationId", conversationId.toString())
+            put("status", "accepted")
+        }
+    }
+}
+
+class FilesGetCapability(
+    private val appContext: Context,
+    private val filesManager: FilesManager,
+) : AppCapability {
+    override val id = "files.get"
+    override val description = "Read metadata for uploaded files, optionally including small file content."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("id", integerSchema("Managed file id."))
+            put("path", stringSchema("Managed relative path under the app files directory."))
+            put("includeContent", booleanSchema("Include file content when the file is at most 1 MiB."))
+        }
+    )
+    override val permissions = setOf(PluginPermission.FilesRead)
+
+    @OptIn(ExperimentalEncodingApi::class)
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val includeContent = input.optionalBoolean("includeContent") ?: false
+        val entity = input.optionalLong("id")?.let { filesManager.get(it) }
+            ?: input.optionalString("path")?.let { path ->
+                if (path.contains("..") || path.startsWith("/")) {
+                    throw BadRequestException("Invalid file path")
+                }
+                filesManager.getByRelativePath(path)
+            }
+            ?: throw BadRequestException("files.get requires id or path")
+
+        val file = filesManager.getFile(entity)
+        if (!file.canonicalPath.startsWith(appContext.filesDir.canonicalPath) || !file.isFile) {
+            throw NotFoundException("File not found")
+        }
+
+        return buildJsonObject {
+            put("id", entity.id)
+            put("folder", entity.folder)
+            put("relativePath", entity.relativePath)
+            put("displayName", entity.displayName)
+            put("mimeType", entity.mimeType)
+            put("sizeBytes", entity.sizeBytes)
+            put("createdAt", entity.createdAt)
+            put("updatedAt", entity.updatedAt)
+            put("url", file.toUri().toString())
+            if (includeContent) {
+                if (file.length() > MAX_FILE_READ_BYTES) {
+                    throw BadRequestException("File is too large to include content")
+                }
+                if (entity.mimeType.startsWith("text/") || entity.mimeType == "application/json") {
+                    put("content", file.readText(Charsets.UTF_8))
+                    put("contentEncoding", "utf-8")
+                } else {
+                    put("contentBase64", Base64.encode(file.readBytes()))
+                    put("contentEncoding", "base64")
+                }
+            }
+        }
+    }
+}
+
+class ToolsListCapability(
+    private val settingsStore: SettingsStore,
+    private val localTools: LocalTools,
+) : AppCapability {
+    override val id = "tools.list"
+    override val description = "List local tools enabled for the current assistant."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.ToolsRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val settings = settingsStore.settingsFlow.first()
+        val assistant = settings.getCurrentAssistant()
+        val tools = localTools.getTools(assistant.localTools)
+        return buildJsonObject {
+            put("assistantId", assistant.id.toString())
+            put(
+                "items",
+                JsonArray(tools.map { tool ->
+                    buildJsonObject {
+                        put("name", tool.name)
+                        put("description", tool.description)
+                        put("parameters", JsonInstant.encodeToJsonElement(tool.parameters()))
+                        put("needsApproval", tool.needsApproval)
+                        put("callableByPlugin", tool.name in SAFE_TOOL_CALLS && !tool.needsApproval)
+                    }
+                })
+            )
+        }
+    }
+}
+
+class ToolsCallCapability(
+    private val settingsStore: SettingsStore,
+    private val localTools: LocalTools,
+) : AppCapability {
+    override val id = "tools.call"
+    override val description = "Execute a low-risk local tool enabled for the current assistant."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("name", stringSchema("Local tool name."))
+            put("arguments", objectSchema(description = "Tool arguments."))
+        },
+        required = listOf("name")
+    )
+    override val permissions = setOf(PluginPermission.ToolsExecute)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val name = input.requiredString("name")
+        if (name !in SAFE_TOOL_CALLS) {
+            throw PluginProtocolException(
+                code = "TOOL_NOT_ALLOWED",
+                message = "Tool is not callable through the plugin gateway: $name"
+            )
+        }
+        val settings = settingsStore.settingsFlow.first()
+        val tool = localTools.getTools(settings.getCurrentAssistant().localTools)
+            .firstOrNull { it.name == name }
+            ?: throw PluginProtocolException("TOOL_NOT_FOUND", "Tool is not enabled: $name")
+        if (tool.needsApproval) {
+            throw PluginProtocolException("TOOL_APPROVAL_REQUIRED", "Tool requires app-side approval: $name")
+        }
+
+        val arguments = input["arguments"]?.jsonObjectOrNull ?: JsonObject(emptyMap())
+        val output = tool.execute(arguments)
+        return buildJsonObject {
+            put("name", tool.name)
+            put("output", JsonInstant.encodeToJsonElement(ListSerializer(UIMessagePart.serializer()), output))
+        }
+    }
+}
+
+class DeviceStatusCapability(
+    private val deviceAgentManager: DeviceAgentManager,
+) : AppCapability {
+    override val id = "device.status"
+    override val description = "Read Shizuku/WiFi ADB readiness and Android device agent status."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.DeviceRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement =
+        JsonInstant.encodeToJsonElement(deviceAgentManager.getStatus())
+}
+
+class DeviceShizukuRequestPermissionCapability(
+    private val deviceAgentManager: DeviceAgentManager,
+) : AppCapability {
+    override val id = "device.shizuku.request_permission"
+    override val description = "Request Shizuku API permission for EterUee. User approval may still be required in Shizuku."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.DeviceControl)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement =
+        JsonInstant.encodeToJsonElement(deviceAgentManager.requestShizukuPermission())
+}
+
+class DeviceAdbShellCapability(
+    private val deviceAgentManager: DeviceAgentManager,
+) : AppCapability {
+    override val id = "device.adb_shell"
+    override val description = "Execute an Android shell command through Shizuku ADB shell."
+    override val inputSchema = shellSchema(
+        defaultWorkingDir = "/data/local/tmp",
+        defaultTimeout = 30,
+    )
+    override val permissions = setOf(PluginPermission.DeviceControl)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val command = input.requiredString("command")
+        return JsonInstant.encodeToJsonElement(
+            deviceAgentManager.executeAdbShell(
+                command = command,
+                workingDir = input.optionalString("workingDir"),
+                stdin = input.optionalString("stdin"),
+                timeoutSeconds = input.optionalInt("timeout") ?: 30,
+            )
+        )
+    }
+}
+
+class LinuxStatusCapability(
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
+) : AppCapability {
+    override val id = "linux.status"
+    override val description = "Read EterUee managed Arch Linux/proot environment readiness."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.DeviceRead)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement =
+        JsonInstant.encodeToJsonElement(linuxEnvironmentManager.getStatus())
+}
+
+class LinuxPrepareCapability(
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
+) : AppCapability {
+    override val id = "linux.prepare"
+    override val description = "Prepare the Arch Linux installer helper in EterUee's app-private files directory."
+    override val inputSchema = emptyObjectSchema()
+    override val permissions = setOf(PluginPermission.DeviceControl)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement =
+        JsonInstant.encodeToJsonElement(linuxEnvironmentManager.prepareInstallerScript())
+}
+
+class LinuxInstallCapability(
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
+) : AppCapability {
+    override val id = "linux.install"
+    override val description =
+        "Download Termux proot runtime packages and extract the Arch Linux rootfs before commands can run."
+    override val inputSchema = objectSchema(
+        properties = buildJsonObject {
+            put("timeout", integerSchema("Install timeout in seconds. Defaults to 600."))
+        }
+    )
+    override val permissions = setOf(PluginPermission.DeviceControl)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement =
+        JsonInstant.encodeToJsonElement(
+            linuxEnvironmentManager.install(
+                timeoutSeconds = input.optionalInt("timeout") ?: 600,
+            )
+        )
+}
+
+class LinuxShellCapability(
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
+) : AppCapability {
+    override val id = "linux.shell"
+    override val description = "Execute a command inside EterUee's managed Arch Linux/proot environment."
+    override val inputSchema = shellSchema(
+        defaultWorkingDir = "/root",
+        defaultTimeout = 60,
+    )
+    override val permissions = setOf(PluginPermission.DeviceControl)
+
+    override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement {
+        val command = input.requiredString("command")
+        return JsonInstant.encodeToJsonElement(
+            linuxEnvironmentManager.execute(
+                command = command,
+                workingDir = input.optionalString("workingDir"),
+                stdin = input.optionalString("stdin"),
+                timeoutSeconds = input.optionalInt("timeout") ?: 60,
+            )
+        )
+    }
+}
+
+private fun Assistant.toPluginJson(isCurrent: Boolean): JsonObject = buildJsonObject {
+    put("id", id.toString())
+    put("name", name)
+    put("isCurrent", isCurrent)
+    put("chatModelId", chatModelId?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("streamOutput", streamOutput)
+    put("contextMessageSize", contextMessageSize)
+    put("enableMemory", enableMemory)
+    put("enableRecentChatsReference", enableRecentChatsReference)
+    put("localTools", JsonArray(localTools.map { JsonPrimitive(it::class.simpleName ?: it.toString()) }))
+    put("mcpServerIds", JsonArray(mcpServers.map { JsonPrimitive(it.toString()) }))
+    put("enabledSkills", JsonArray(enabledSkills.sorted().map { JsonPrimitive(it) }))
+    put("allowConversationSystemPrompt", allowConversationSystemPrompt)
+    put("allowConversationPromptInjection", allowConversationPromptInjection)
+}
+
+private fun emptyObjectSchema(): JsonObject = objectSchema()
+
+private fun objectSchema(
+    description: String? = null,
+    properties: JsonObject = JsonObject(emptyMap()),
+    required: List<String> = emptyList(),
+): JsonObject = buildJsonObject {
+    put("type", "object")
+    description?.let { put("description", it) }
+    put("properties", properties)
+    if (required.isNotEmpty()) {
+        put("required", JsonArray(required.map { JsonPrimitive(it) }))
+    }
+}
+
+private fun stringSchema(description: String): JsonObject = buildJsonObject {
+    put("type", "string")
+    put("description", description)
+}
+
+private fun integerSchema(description: String): JsonObject = buildJsonObject {
+    put("type", "integer")
+    put("description", description)
+}
+
+private fun booleanSchema(description: String): JsonObject = buildJsonObject {
+    put("type", "boolean")
+    put("description", description)
+}
+
+private fun arraySchema(description: String): JsonObject = buildJsonObject {
+    put("type", "array")
+    put("description", description)
+}
+
+private fun shellSchema(
+    defaultWorkingDir: String,
+    defaultTimeout: Int,
+): JsonObject = objectSchema(
+    properties = buildJsonObject {
+        put("command", stringSchema("Shell command to execute."))
+        put("workingDir", stringSchema("Working directory. Defaults to $defaultWorkingDir."))
+        put("stdin", stringSchema("Optional standard input for the command."))
+        put("timeout", integerSchema("Timeout in seconds. Defaults to $defaultTimeout."))
+    },
+    required = listOf("command")
+)
+
+private fun JsonObject.requiredString(key: String): String =
+    optionalString(key)?.takeIf { it.isNotBlank() } ?: throw BadRequestException("$key is required")
+
+private fun JsonObject.requiredUuid(key: String): Uuid = parseUuid(requiredString(key), key)
+
+private fun JsonObject.optionalString(key: String): String? =
+    this[key]?.jsonPrimitiveOrNull?.contentOrNull
+
+private fun JsonObject.optionalBoolean(key: String): Boolean? =
+    this[key]?.jsonPrimitiveOrNull?.let { primitive ->
+        primitive.contentOrNull?.toBooleanStrictOrNull()
+    }
+
+private fun JsonObject.optionalInt(key: String): Int? =
+    this[key]?.jsonPrimitiveOrNull?.intOrNull
+
+private fun JsonObject.optionalLong(key: String): Long? =
+    this[key]?.jsonPrimitiveOrNull?.contentOrNull?.toLongOrNull()
+
+private val JsonElement.jsonPrimitiveOrNull
+    get() = this as? JsonPrimitive
+
+private val JsonElement.jsonObjectOrNull
+    get() = this as? JsonObject
+
+private fun parseUuid(value: String, field: String): Uuid =
+    runCatching { Uuid.parse(value) }.getOrElse {
+        throw BadRequestException("Invalid $field")
+    }
+
+private fun JsonObject.toMessageParts(): List<UIMessagePart> {
+    val text = optionalString("text")?.takeIf { it.isNotBlank() }
+    if (text != null) {
+        return listOf(UIMessagePart.Text(text))
+    }
+    val parts = this["parts"]?.let { element ->
+        runCatching {
+            JsonInstant.decodeFromJsonElement(
+                ListSerializer(UIMessagePart.serializer()),
+                element.jsonArray
+            )
+        }.getOrElse {
+            throw BadRequestException("Invalid parts")
+        }
+    }
+    return parts.orEmpty()
+}

--- a/app/src/main/java/com/eterultimate/eteruee/plugin/PluginCapability.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/plugin/PluginCapability.kt
@@ -1,0 +1,51 @@
+package com.eterultimate.eteruee.plugin
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+interface AppCapability {
+    val id: String
+    val description: String
+    val inputSchema: JsonObject
+    val permissions: Set<PluginPermission>
+
+    suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement
+}
+
+data class PluginCallContext(
+    val connectionId: String,
+    val grantedPermissions: Set<PluginPermission>,
+    val principal: String? = null,
+) {
+    fun requirePermissions(required: Set<PluginPermission>) {
+        val missing = required - grantedPermissions
+        if (missing.isNotEmpty()) {
+            throw PluginPermissionDeniedException(missing)
+        }
+    }
+}
+
+class PluginProtocolException(
+    val code: String,
+    override val message: String,
+) : RuntimeException(message)
+
+class PluginPermissionDeniedException(
+    val missing: Set<PluginPermission>,
+) : RuntimeException("Missing plugin permissions: ${missing.joinToString { it.scope }}")
+
+@Serializable
+data class AppCapabilityDescriptor(
+    val id: String,
+    val description: String,
+    val inputSchema: JsonObject,
+    val permissions: List<String>,
+)
+
+fun AppCapability.toDescriptor() = AppCapabilityDescriptor(
+    id = id,
+    description = description,
+    inputSchema = inputSchema,
+    permissions = permissions.map { it.scope }.sorted(),
+)

--- a/app/src/main/java/com/eterultimate/eteruee/plugin/PluginPermission.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/plugin/PluginPermission.kt
@@ -1,0 +1,20 @@
+package com.eterultimate.eteruee.plugin
+
+enum class PluginPermission(val scope: String) {
+    ConversationRead("conversation:read"),
+    ConversationWrite("conversation:write"),
+    AssistantRead("assistant:read"),
+    AssistantWrite("assistant:write"),
+    SettingsRead("settings:read"),
+    FilesRead("files:read"),
+    FilesWrite("files:write"),
+    ToolsRead("tools:read"),
+    ToolsExecute("tools:execute"),
+    DeviceRead("device:read"),
+    DeviceControl("device:control"),
+    NetworkRelay("network:relay");
+
+    companion object {
+        fun fromScope(scope: String): PluginPermission? = entries.firstOrNull { it.scope == scope }
+    }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/plugin/PluginProtocol.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/plugin/PluginProtocol.kt
@@ -1,0 +1,64 @@
+package com.eterultimate.eteruee.plugin
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+@Serializable
+data class PluginRequest(
+    val id: String? = null,
+    val type: PluginMessageType,
+    val method: String? = null,
+    val params: JsonObject = JsonObject(emptyMap()),
+    val topic: String? = null,
+)
+
+@Serializable
+enum class PluginMessageType {
+    @SerialName("call")
+    Call,
+
+    @SerialName("list_capabilities")
+    ListCapabilities,
+
+    @SerialName("subscribe")
+    Subscribe,
+
+    @SerialName("unsubscribe")
+    Unsubscribe,
+}
+
+fun pluginResult(id: String?, result: JsonElement): JsonObject = buildJsonObject {
+    id?.let { put("id", it) }
+    put("type", "result")
+    put("result", result)
+}
+
+fun pluginError(
+    id: String?,
+    code: String,
+    message: String,
+    details: JsonElement? = null,
+): JsonObject = buildJsonObject {
+    id?.let { put("id", it) }
+    put("type", "error")
+    put(
+        "error",
+        buildJsonObject {
+            put("code", code)
+            put("message", message)
+            details?.let { put("details", it) }
+        }
+    )
+}
+
+fun pluginUnsupportedSubscriptionResult(topic: String?) = buildJsonObject {
+    put("subscribed", false)
+    put("topic", topic?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("reason", "No subscription topics are available in the plugin WebSocket MVP.")
+}

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/AssistantLocalToolPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/AssistantLocalToolPage.kt
@@ -200,6 +200,20 @@ private fun AssistantLocalToolContent(
             )
             item(
                 headlineContent = {
+                    Text(stringResource(R.string.assistant_page_local_tools_linux_environment_title))
+                },
+                supportingContent = {
+                    Text(stringResource(R.string.assistant_page_local_tools_linux_environment_desc))
+                },
+                trailingContent = {
+                    Switch(
+                        checked = assistant.localTools.contains(LocalToolOption.LinuxEnvironment),
+                        onCheckedChange = { toggleLocalTool(LocalToolOption.LinuxEnvironment, it) }
+                    )
+                }
+            )
+            item(
+                headlineContent = {
                     Text(stringResource(R.string.assistant_page_local_tools_traffic_control_title))
                 },
                 supportingContent = {

--- a/app/src/main/java/com/eterultimate/eteruee/web/WebApiModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/WebApiModule.kt
@@ -27,6 +27,8 @@ import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.repository.ConversationRepository
 import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
 import com.eterultimate.eteruee.device.DeviceAgentManager
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
+import com.eterultimate.eteruee.plugin.createBuiltInAppCapabilityRegistry
 import com.eterultimate.eteruee.roleplay.domain.service.CharacterService as RoleplayCharacterService
 import com.eterultimate.eteruee.roleplay.domain.service.ChatService as RoleplayChatService
 import com.eterultimate.eteruee.roleplay.domain.service.GroupService as RoleplayGroupService
@@ -44,6 +46,7 @@ import com.eterultimate.eteruee.web.routes.backupRoutes
 import com.eterultimate.eteruee.web.routes.conversationRoutes
 import com.eterultimate.eteruee.web.routes.deviceRoutes
 import com.eterultimate.eteruee.web.routes.filesRoutes
+import com.eterultimate.eteruee.web.routes.pluginRoutes
 import com.eterultimate.eteruee.web.routes.relayRoutes
 import com.eterultimate.eteruee.web.routes.roleplayRoutes
 import com.eterultimate.eteruee.web.routes.settingsRoutes
@@ -85,8 +88,19 @@ fun Application.configureWebApi(
     roleplayPresetService: RoleplayPresetService,
     localTools: LocalTools,
     deviceAgentManager: DeviceAgentManager,
+    linuxEnvironmentManager: LinuxEnvironmentManager,
 ) {
     val jwtEnabled = settingsStore.settingsFlow.value.webServerJwtEnabled
+    val pluginCapabilityRegistry = createBuiltInAppCapabilityRegistry(
+        context = context,
+        settingsStore = settingsStore,
+        conversationRepo = conversationRepo,
+        chatService = chatService,
+        filesManager = filesManager,
+        localTools = localTools,
+        deviceAgentManager = deviceAgentManager,
+        linuxEnvironmentManager = linuxEnvironmentManager,
+    )
 
     install(ContentNegotiation) {
         json(JsonInstant)
@@ -197,7 +211,7 @@ fun Application.configureWebApi(
                         settingsStore = settingsStore,
                         filesManager = filesManager,
                     )
-                    deviceRoutes(deviceAgentManager)
+                    deviceRoutes(deviceAgentManager, linuxEnvironmentManager)
                     backupRoutes(context, settingsStore, webDavSync)
                     relayRoutes(httpRelayService)
                     roleplayRoutes(
@@ -210,6 +224,7 @@ fun Application.configureWebApi(
                         presetService = roleplayPresetService,
                         localTools = localTools,
                     )
+                    pluginRoutes(pluginCapabilityRegistry)
                 }
             } else {
                 agentApiRoutes(
@@ -220,7 +235,7 @@ fun Application.configureWebApi(
                     settingsStore = settingsStore,
                     filesManager = filesManager,
                 )
-                deviceRoutes(deviceAgentManager)
+                deviceRoutes(deviceAgentManager, linuxEnvironmentManager)
                 backupRoutes(context, settingsStore, webDavSync)
                 relayRoutes(httpRelayService)
                 roleplayRoutes(
@@ -233,6 +248,7 @@ fun Application.configureWebApi(
                     presetService = roleplayPresetService,
                     localTools = localTools,
                 )
+                pluginRoutes(pluginCapabilityRegistry)
             }
         }
     }

--- a/app/src/main/java/com/eterultimate/eteruee/web/WebServerManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/WebServerManager.kt
@@ -19,6 +19,7 @@ import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.repository.ConversationRepository
 import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
 import com.eterultimate.eteruee.device.DeviceAgentManager
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
 import com.eterultimate.eteruee.roleplay.domain.service.CharacterService as RoleplayCharacterService
 import com.eterultimate.eteruee.roleplay.domain.service.ChatService as RoleplayChatService
 import com.eterultimate.eteruee.roleplay.domain.service.GroupService as RoleplayGroupService
@@ -62,6 +63,7 @@ class WebServerManager(
     private val roleplayPresetService: RoleplayPresetService,
     private val localTools: LocalTools,
     private val deviceAgentManager: DeviceAgentManager,
+    private val linuxEnvironmentManager: LinuxEnvironmentManager,
 ) {
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private val nsdRegistrar = NsdServiceRegistrar(context)
@@ -112,6 +114,7 @@ class WebServerManager(
                         roleplayPresetService = roleplayPresetService,
                         localTools = localTools,
                         deviceAgentManager = deviceAgentManager,
+                        linuxEnvironmentManager = linuxEnvironmentManager,
                     )
                 }.start(wait = false)
 

--- a/app/src/main/java/com/eterultimate/eteruee/web/routes/DeviceRoutes.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/routes/DeviceRoutes.kt
@@ -2,6 +2,8 @@ package com.eterultimate.eteruee.web.routes
 
 import com.eterultimate.eteruee.device.DeviceAgentManager
 import com.eterultimate.eteruee.device.DeviceShellResult
+import com.eterultimate.eteruee.linux.LinuxCommandResult
+import com.eterultimate.eteruee.linux.LinuxEnvironmentManager
 import com.eterultimate.eteruee.web.BadRequestException
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
@@ -14,6 +16,7 @@ import kotlinx.serialization.Serializable
 
 fun Route.deviceRoutes(
     deviceAgentManager: DeviceAgentManager,
+    linuxEnvironmentManager: LinuxEnvironmentManager,
 ) {
     route("/device") {
         get("/status") {
@@ -50,8 +53,46 @@ fun Route.deviceRoutes(
             )
             call.respond(HttpStatusCode.OK, result)
         }
+
+        route("/linux") {
+            get("/status") {
+                call.respond(linuxEnvironmentManager.getStatus())
+            }
+
+            post("/prepare") {
+                call.respond(linuxEnvironmentManager.prepareInstallerScript())
+            }
+
+            post("/install") {
+                val request = runCatching { call.receive<LinuxInstallRequest>() }
+                    .getOrDefault(LinuxInstallRequest())
+                val result = linuxEnvironmentManager.install(
+                    timeoutSeconds = request.timeoutSeconds,
+                )
+                call.respond(HttpStatusCode.OK, result)
+            }
+
+            post("/shell") {
+                val request = call.receive<DeviceShellRequest>()
+                if (request.command.isBlank()) {
+                    throw BadRequestException("command must not be blank")
+                }
+                val result: LinuxCommandResult = linuxEnvironmentManager.execute(
+                    command = request.command,
+                    workingDir = request.workingDir,
+                    stdin = request.stdin,
+                    timeoutSeconds = request.timeoutSeconds,
+                )
+                call.respond(HttpStatusCode.OK, result)
+            }
+        }
     }
 }
+
+@Serializable
+data class LinuxInstallRequest(
+    val timeoutSeconds: Int = 600,
+)
 
 @Serializable
 data class DeviceShellRequest(

--- a/app/src/main/java/com/eterultimate/eteruee/web/routes/PluginRoutes.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/web/routes/PluginRoutes.kt
@@ -1,0 +1,156 @@
+package com.eterultimate.eteruee.web.routes
+
+import com.eterultimate.eteruee.plugin.AppCapabilityRegistry
+import com.eterultimate.eteruee.plugin.PluginCallContext
+import com.eterultimate.eteruee.plugin.PluginMessageType
+import com.eterultimate.eteruee.plugin.PluginPermissionDeniedException
+import com.eterultimate.eteruee.plugin.PluginProtocolException
+import com.eterultimate.eteruee.plugin.PluginRequest
+import com.eterultimate.eteruee.plugin.defaultPluginPermissions
+import com.eterultimate.eteruee.plugin.pluginError
+import com.eterultimate.eteruee.plugin.pluginResult
+import com.eterultimate.eteruee.plugin.pluginUnsupportedSubscriptionResult
+import com.eterultimate.eteruee.utils.JsonInstant
+import com.eterultimate.eteruee.web.ApiException
+import java.util.UUID
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+import io.ktor.server.auth.principal
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import io.ktor.server.routing.Route
+import io.ktor.server.websocket.webSocket
+
+fun Route.pluginRoutes(
+    registry: AppCapabilityRegistry,
+) {
+    webSocket("/plugins/ws") {
+        val pluginContext = PluginCallContext(
+            connectionId = UUID.randomUUID().toString(),
+            grantedPermissions = defaultPluginPermissions(),
+            principal = call.principalNameOrNull(),
+        )
+
+        for (frame in incoming) {
+            if (frame !is Frame.Text) {
+                sendPluginError(
+                    id = null,
+                    code = "UNSUPPORTED_FRAME",
+                    message = "Only text frames are supported."
+                )
+                continue
+            }
+
+            val request = try {
+                JsonInstant.decodeFromString(PluginRequest.serializer(), frame.readText())
+            } catch (e: SerializationException) {
+                sendPluginError(
+                    id = null,
+                    code = "INVALID_REQUEST",
+                    message = e.message ?: "Invalid plugin request."
+                )
+                continue
+            } catch (e: IllegalArgumentException) {
+                sendPluginError(
+                    id = null,
+                    code = "INVALID_REQUEST",
+                    message = e.message ?: "Invalid plugin request."
+                )
+                continue
+            }
+
+            try {
+                when (request.type) {
+                    PluginMessageType.ListCapabilities -> {
+                        sendPluginResult(
+                            id = request.id,
+                            result = buildJsonObject {
+                                put(
+                                    "items",
+                                    JsonInstant.encodeToJsonElement(
+                                        ListSerializer(
+                                            com.eterultimate.eteruee.plugin.AppCapabilityDescriptor.serializer()
+                                        ),
+                                        registry.list()
+                                    )
+                                )
+                            }
+                        )
+                    }
+
+                    PluginMessageType.Call -> {
+                        val method = request.method?.takeIf { it.isNotBlank() }
+                            ?: throw PluginProtocolException("INVALID_REQUEST", "method is required for call messages")
+                        val result = registry.execute(method, request.params, pluginContext)
+                        sendPluginResult(request.id, result)
+                    }
+
+                    PluginMessageType.Subscribe,
+                    PluginMessageType.Unsubscribe,
+                        -> {
+                        sendPluginResult(
+                            id = request.id,
+                            result = pluginUnsupportedSubscriptionResult(request.topic)
+                        )
+                    }
+                }
+            } catch (e: PluginPermissionDeniedException) {
+                sendPluginError(
+                    id = request.id,
+                    code = "PERMISSION_DENIED",
+                    message = e.message ?: "Permission denied",
+                    details = buildJsonObject {
+                        put(
+                            "missing",
+                            JsonArray(e.missing.map { JsonPrimitive(it.scope) })
+                        )
+                    }
+                )
+            } catch (e: PluginProtocolException) {
+                sendPluginError(request.id, e.code, e.message)
+            } catch (e: ApiException) {
+                sendPluginError(
+                    id = request.id,
+                    code = e.status.value.toString(),
+                    message = e.message
+                )
+            } catch (e: IllegalArgumentException) {
+                sendPluginError(
+                    id = request.id,
+                    code = "INVALID_PARAMS",
+                    message = e.message ?: "Invalid params"
+                )
+            } catch (e: Throwable) {
+                sendPluginError(
+                    id = request.id,
+                    code = "INTERNAL_ERROR",
+                    message = e.message ?: e.javaClass.simpleName
+                )
+            }
+        }
+    }
+}
+
+private suspend fun io.ktor.server.websocket.DefaultWebSocketServerSession.sendPluginResult(
+    id: String?,
+    result: kotlinx.serialization.json.JsonElement,
+) {
+    send(Frame.Text(JsonInstant.encodeToString(pluginResult(id, result))))
+}
+
+private suspend fun io.ktor.server.websocket.DefaultWebSocketServerSession.sendPluginError(
+    id: String?,
+    code: String,
+    message: String,
+    details: kotlinx.serialization.json.JsonElement? = null,
+) {
+    send(Frame.Text(JsonInstant.encodeToString(pluginError(id, code, message, details))))
+}
+
+private fun io.ktor.server.application.ApplicationCall.principalNameOrNull(): String? =
+    principal<io.ktor.server.auth.jwt.JWTPrincipal>()?.payload?.subject

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1140,6 +1140,8 @@
   <string name="ssh_page_title">SSH</string>
   <string name="assistant_page_local_tools_shell_desc">Execute shell commands on the device</string>
   <string name="assistant_page_local_tools_shell_title">Shell</string>
+  <string name="assistant_page_local_tools_linux_environment_desc">Prepare and use the managed Arch Linux environment after approval</string>
+  <string name="assistant_page_local_tools_linux_environment_title">Arch Linux</string>
   <string name="assistant_page_local_tools_ssh_desc">Execute commands on remote servers via SSH</string>
   <string name="assistant_page_local_tools_ssh_title">SSH</string>
   <string name="assistant_page_local_tools_traffic_control_desc">Inspect and control local Hiddify Core traffic routing</string>

--- a/app/src/test/java/com/eterultimate/eteruee/data/datastore/DefaultIntegrationsTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/data/datastore/DefaultIntegrationsTest.kt
@@ -1,0 +1,83 @@
+package com.eterultimate.eteruee.data.datastore
+
+import com.eterultimate.eteruee.ai.provider.ProviderSetting
+import com.eterultimate.eteruee.data.ai.mcp.McpServerConfig
+import com.eterultimate.eteruee.data.ai.tools.LocalToolOption
+import com.eterultimate.eteruee.data.datastore.migration.mergeDefaultAssistantRuntimeAccess
+import com.eterultimate.eteruee.utils.JsonInstant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultIntegrationsTest {
+    @Test
+    fun defaultLocalSapiProviderUsesAndroidHostLoopback() {
+        val provider = DEFAULT_PROVIDERS
+            .filterIsInstance<ProviderSetting.OpenAI>()
+            .first { it.id == DEFAULT_LOCAL_SAPI_PROVIDER_ID }
+
+        assertEquals("SAPI Local", provider.name)
+        assertEquals("http://10.0.2.2:3000/v1", provider.baseUrl)
+        assertEquals(false, provider.enabled)
+        assertTrue(provider.models.any { it.modelId == "auto" })
+    }
+
+    @Test
+    fun defaultJshookMcpUsesHostStreamableHttpEndpoint() {
+        val config = DEFAULT_MCP_SERVERS.single { it.id == DEFAULT_JSHOOK_MCP_SERVER_ID }
+
+        assertEquals("jshookmcp", config.commonOptions.name)
+        assertEquals("http://10.0.2.2:3001/mcp", config.url)
+        assertEquals(true, config.commonOptions.enable)
+    }
+
+    @Test
+    fun defaultAssistantEnablesJshookMcp() {
+        val assistant = DEFAULT_ASSISTANTS.single { it.id == DEFAULT_ASSISTANT_ID }
+
+        assertTrue(assistant.mcpServers.contains(DEFAULT_JSHOOK_MCP_SERVER_ID))
+    }
+
+    @Test
+    fun defaultAssistantExposesRuntimeToolsToLlm() {
+        val assistant = DEFAULT_ASSISTANTS.single { it.id == DEFAULT_ASSISTANT_ID }
+
+        assertTrue(assistant.localTools.contains(LocalToolOption.Shell))
+        assertTrue(assistant.localTools.contains(LocalToolOption.LinuxEnvironment))
+        assertTrue(assistant.localTools.contains(LocalToolOption.DeviceAgent))
+    }
+
+    @Test
+    fun linuxEnvironmentToolOptionHasStableSerializedName() {
+        val options: List<LocalToolOption> = listOf(LocalToolOption.LinuxEnvironment)
+        val encoded = JsonInstant.encodeToString(options)
+
+        assertEquals("""[{"type":"linux_environment"}]""", encoded)
+    }
+
+    @Test
+    fun migrationAddsDefaultRuntimeAccessToExistingDefaultAssistant() {
+        val migrated = mergeDefaultAssistantRuntimeAccess(
+            """
+                [
+                  {
+                    "id": "$DEFAULT_ASSISTANT_ID",
+                    "name": "",
+                    "systemPrompt": "",
+                    "mcpServers": [],
+                    "localTools": [{"type":"time_info"}]
+                  }
+                ]
+            """.trimIndent()
+        )
+
+        val assistants: List<com.eterultimate.eteruee.data.model.Assistant> =
+            JsonInstant.decodeFromString(migrated)
+        val assistant = assistants.single()
+
+        assertTrue(assistant.mcpServers.contains(DEFAULT_JSHOOK_MCP_SERVER_ID))
+        assertTrue(assistant.localTools.contains(LocalToolOption.Shell))
+        assertTrue(assistant.localTools.contains(LocalToolOption.LinuxEnvironment))
+        assertTrue(assistant.localTools.contains(LocalToolOption.DeviceAgent))
+    }
+}

--- a/app/src/test/java/com/eterultimate/eteruee/plugin/AppCapabilityRegistryTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/plugin/AppCapabilityRegistryTest.kt
@@ -1,0 +1,86 @@
+package com.eterultimate.eteruee.plugin
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppCapabilityRegistryTest {
+    @Test
+    fun executeReturnsCapabilityResultWhenPermissionGranted() = runBlocking {
+        val registry = AppCapabilityRegistry(listOf(EchoCapability))
+        val context = PluginCallContext(
+            connectionId = "test",
+            grantedPermissions = setOf(PluginPermission.SettingsRead),
+        )
+
+        val result = registry.execute(
+            method = "test.echo",
+            input = buildJsonObject { put("value", "ok") },
+            context = context,
+        )
+
+        assertEquals(buildJsonObject { put("value", "ok") }, result)
+    }
+
+    @Test
+    fun executeRejectsMissingPermission() = runBlocking {
+        val registry = AppCapabilityRegistry(listOf(EchoCapability))
+        val context = PluginCallContext(
+            connectionId = "test",
+            grantedPermissions = emptySet(),
+        )
+
+        val error = runCatching {
+            registry.execute("test.echo", JsonObject(emptyMap()), context)
+        }.exceptionOrNull() as PluginPermissionDeniedException
+
+        assertEquals(setOf(PluginPermission.SettingsRead), error.missing)
+    }
+
+    @Test
+    fun executeRejectsUnknownCapability() = runBlocking {
+        val registry = AppCapabilityRegistry(listOf(EchoCapability))
+        val context = PluginCallContext(
+            connectionId = "test",
+            grantedPermissions = setOf(PluginPermission.SettingsRead),
+        )
+
+        val error = runCatching {
+            registry.execute("missing.method", JsonObject(emptyMap()), context)
+        }.exceptionOrNull() as PluginProtocolException
+
+        assertEquals("METHOD_NOT_FOUND", error.code)
+    }
+
+    @Test
+    fun listReturnsSortedDescriptorsWithScopeNames() {
+        val registry = AppCapabilityRegistry(listOf(WriteCapability, EchoCapability))
+
+        val descriptors = registry.list()
+
+        assertEquals(listOf("test.echo", "test.write"), descriptors.map { it.id })
+        assertEquals(listOf("settings:read"), descriptors.first().permissions)
+    }
+
+    private object EchoCapability : AppCapability {
+        override val id = "test.echo"
+        override val description = "Echo params."
+        override val inputSchema = JsonObject(emptyMap())
+        override val permissions = setOf(PluginPermission.SettingsRead)
+
+        override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement = input
+    }
+
+    private object WriteCapability : AppCapability {
+        override val id = "test.write"
+        override val description = "Write test."
+        override val inputSchema = JsonObject(emptyMap())
+        override val permissions = setOf(PluginPermission.ConversationWrite)
+
+        override suspend fun execute(input: JsonObject, context: PluginCallContext): JsonElement = input
+    }
+}

--- a/app/src/test/java/com/eterultimate/eteruee/plugin/PluginProtocolTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/plugin/PluginProtocolTest.kt
@@ -1,0 +1,57 @@
+package com.eterultimate.eteruee.plugin
+
+import com.eterultimate.eteruee.utils.JsonInstant
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PluginProtocolTest {
+    @Test
+    fun parsesCallRequestWithParams() {
+        val request = JsonInstant.decodeFromString(
+            PluginRequest.serializer(),
+            """{"id":"1","type":"call","method":"conversation.list","params":{"limit":20}}"""
+        )
+
+        assertEquals("1", request.id)
+        assertEquals(PluginMessageType.Call, request.type)
+        assertEquals("conversation.list", request.method)
+        assertEquals("20", request.params["limit"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun resultEnvelopeUsesJsonRpcStyleShape() {
+        val result = pluginResult(
+            id = "1",
+            result = buildJsonObject { put("status", "ok") },
+        )
+
+        assertEquals("1", result["id"]?.jsonPrimitive?.content)
+        assertEquals("result", result["type"]?.jsonPrimitive?.content)
+        assertEquals("ok", result["result"]?.jsonObject?.get("status")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun errorEnvelopeIncludesCodeAndMessage() {
+        val error = pluginError(
+            id = "1",
+            code = "METHOD_NOT_FOUND",
+            message = "Unknown capability",
+        )
+
+        assertEquals("error", error["type"]?.jsonPrimitive?.content)
+        assertEquals("METHOD_NOT_FOUND", error["error"]?.jsonObject?.get("code")?.jsonPrimitive?.content)
+        assertEquals("Unknown capability", error["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun permissionScopeRoundTripUsesStableStrings() {
+        assertEquals(PluginPermission.ConversationRead, PluginPermission.fromScope("conversation:read"))
+        assertEquals(PluginPermission.DeviceRead, PluginPermission.fromScope("device:read"))
+        assertEquals(PluginPermission.DeviceControl, PluginPermission.fromScope("device:control"))
+        assertEquals(null, PluginPermission.fromScope("unknown:scope"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 commons-text = "1.15.0"
+commons-compress = "1.28.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.04.01"
@@ -66,6 +67,8 @@ jmdns = "3.6.3"
 slf4j = "2.0.18"
 jsch = "0.2.18"
 shizuku = "13.1.5"
+xz = "1.10"
+zstd-jni = "1.5.7-10"
 
 [libraries]
 androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "cameraCore" }
@@ -147,6 +150,7 @@ sonner = { module = "io.github.dokar3:sonner", version.ref = "sonner" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
 modelcontextprotocol-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
 pebble = { module = "io.pebbletemplates:pebble", version.ref = "pebble" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
@@ -170,6 +174,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-host-common = { module = "io.ktor:ktor-server-host-common", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
@@ -182,6 +187,8 @@ slf4j-android = { module = "uk.uuid.slf4j:slf4j-android", version = "2.0.17-0" }
 jsch = { module = "com.github.mwiede:jsch", version.ref = "jsch" }
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
+xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
+zstd-jni = { group = "com.github.luben", name = "zstd-jni", version.ref = "zstd-jni" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     api(libs.ktor.server.content.negotiation)
     api(libs.ktor.server.status.pages)
     api(libs.ktor.server.sse)
+    api(libs.ktor.server.websockets)
     api(libs.ktor.server.cio)
 
     testImplementation(libs.junit)

--- a/web/src/main/java/com/eterultimate/eteruee/web/Entry.kt
+++ b/web/src/main/java/com/eterultimate/eteruee/web/Entry.kt
@@ -15,6 +15,7 @@ import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
+import io.ktor.server.websocket.WebSockets
 
 fun startWebServer(
     port: Int = WebUiConfig.DEFAULT_PORT,
@@ -31,6 +32,7 @@ fun startWebServer(
             anyMethod()
         }
         install(SSE)
+        install(WebSockets)
         install(DefaultHeaders)
         routing {
             staticResources("/", "static") {


### PR DESCRIPTION
## Summary
- Add a managed Arch Linux/proot runtime manager and expose it through `linux_environment`, `shell_execute`, `/device/linux/*`, and the plugin gateway.
- Add default local runtime integrations: disabled `SAPI Local` provider at `http://10.0.2.2:3000/v1`, enabled `jshookmcp` MCP at `http://10.0.2.2:3001/mcp`, and default assistant runtime tools.
- Request Android 37+ `ACCESS_LOCAL_NETWORK` only when enabled local runtime endpoints require emulator/host LAN access.
- Add a WebSocket plugin gateway with permission-scoped built-in app capabilities for app info, settings, conversations, files, tools, Shizuku/device status, and Linux runtime operations.

## Validation
- `./gradlew.bat lintDebug testDebugUnitTest assembleDebug --no-daemon --stacktrace --console=plain` passed in the clean PR worktree.
- Emulator smoke on API 37 x86_64 installed `app-x86_64-debug.apk`, cold launched `RouteActivity`, and kept the app process alive with no `FATAL EXCEPTION`/ANR in filtered logcat.
- Smoke confirmed `ACCESS_LOCAL_NETWORK` and `moe.shizuku.manager.permission.API_V23` granted on the emulator.
- Smoke confirmed SAPI and jshook host services were reachable through emulator host loopback, and EterUee connected to `jshookmcp` via `http://10.0.2.2:3001/mcp` with `tools/list` and SSE session success.

## Notes
- Full Arch rootfs/proot installation was not run during smoke because it requires invoking the approved app-side Linux install path and downloads a rootfs. The installer path is wired and covered by build/unit tests, but end-to-end rootfs extraction should be reviewed before relying on it in production.
- Shizuku/WiFi ADB capability still depends on Shizuku being installed, running, and granted by the user or device policy; this PR exposes readiness and command paths but does not silently grant privileged access.
- Direct adb startup of the web server service was not smoke-tested because the service is non-exported by design.

## Summary by Sourcery

Expose the managed Arch Linux/proot runtime and local device capabilities to LLMs and external plugins via new tools, web APIs, and a WebSocket plugin gateway.

New Features:
- Add a linux_environment tool and enhance shell_execute to run commands in a managed Arch Linux/proot or Android shell environment with status reporting.
- Introduce default local integrations including a disabled SAPI Local provider, an enabled jshookmcp MCP server, and default assistant runtime tool selection.
- Implement a WebSocket-based plugin gateway with permission-scoped app capabilities for app info, settings, conversations, files, tools, device status, and Linux runtime operations.
- Add API routes and capabilities to inspect, prepare, install, and execute commands inside the managed Arch Linux environment via /device/linux/* and plugin methods.

Enhancements:
- Automatically request ACCESS_LOCAL_NETWORK on Android 37+ when settings reference local-network providers or MCP servers.
- Extend default settings, migrations, and assistant configuration to seed and preserve the new local runtime integrations across upgrades.

Build:
- Add dependencies for commons-compress, xz, zstd-jni, and Ktor WebSockets to support Arch rootfs extraction and WebSocket plugins.

Tests:
- Add unit tests covering plugin capability registry behavior, plugin protocol envelopes and permission scopes, default local integrations, and assistant runtime migration logic.