### PR TITLE
fix: port upstream chat and MCP safeguards

### DIFF
--- a/ai/src/main/java/com/eterultimate/eteruee/ai/ui/Message.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/ui/Message.kt
@@ -159,13 +159,14 @@ data class UIMessage(
         } ?: this
     }
 
-    fun summaryAsText(): String {
-        return "[${role.name}]: " + parts.joinToString(separator = "\n") { part ->
+    fun summaryAsText(maxLength: Int = Int.MAX_VALUE): String {
+        val text = "[${role.name}]: " + parts.joinToString(separator = "\n") { part ->
             when (part) {
                 is UIMessagePart.Text -> part.text
                 else -> ""
             }
         }
+        return if (text.length > maxLength) text.take(maxLength) + "..." else text
     }
 
     fun toText() = parts.joinToString(separator = "\n") { part ->

--- a/ai/src/test/java/com/eterultimate/eteruee/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/com/eterultimate/eteruee/ai/ui/MessageTest.kt
@@ -175,6 +175,26 @@ class MessageTest {
         assertTrue(message.isValidToUpload())
     }
 
+    @Test
+    fun `summaryAsText should preserve existing full text by default`() {
+        val message = UIMessage(
+            role = MessageRole.USER,
+            parts = listOf(UIMessagePart.Text("hello world"))
+        )
+
+        assertEquals("[USER]: hello world", message.summaryAsText())
+    }
+
+    @Test
+    fun `summaryAsText should truncate long text when max length is provided`() {
+        val message = UIMessage(
+            role = MessageRole.USER,
+            parts = listOf(UIMessagePart.Text("hello world"))
+        )
+
+        assertEquals("[USER]: he...", message.summaryAsText(maxLength = 10))
+    }
+
     // ==================== migrateToolMessages Tests ====================
 
     @Test

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/ChatToolExecutor.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/ChatToolExecutor.kt
@@ -12,8 +12,8 @@ import com.eterultimate.eteruee.data.datastore.getCurrentAssistant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import com.eterultimate.eteruee.ai.core.Tool
+import com.eterultimate.eteruee.data.ai.mcp.mcpProviderToolName
 import com.eterultimate.eteruee.utils.JsonInstant
-import kotlinx.serialization.json.JsonElement
 
 class ChatToolExecutor(
     private val settings: Settings,
@@ -39,10 +39,10 @@ class ChatToolExecutor(
                         )
                     )
                 }
-                mcpManager.getAllAvailableTools().forEach { (serverId, tool) ->
+                mcpManager.getAllAvailableTools().forEach { (serverId, _, tool) ->
                     add(
                         Tool(
-                            name = "mcp__" + tool.name,
+                            name = mcpProviderToolName(serverId, tool.name),
                             description = tool.description ?: "",
                             parameters = { tool.inputSchema },
                             needsApproval = tool.needsApproval,

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/mcp/McpManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/mcp/McpManager.kt
@@ -55,6 +55,25 @@ private const val TAG = "McpManager"
 private const val MAX_RECONNECT_ATTEMPTS = 5
 private const val BASE_RECONNECT_DELAY_MS = 1000L
 private const val MAX_RECONNECT_DELAY_MS = 30000L
+private const val MCP_TOOL_PREFIX = "mcp__"
+private const val MCP_TOOL_SERVER_KEY_LENGTH = 12
+
+internal fun mcpProviderToolName(serverId: Uuid, toolName: String): String {
+    val serverKey = serverId.toString().replace("-", "").take(MCP_TOOL_SERVER_KEY_LENGTH)
+    return "$MCP_TOOL_PREFIX${serverKey}__$toolName"
+}
+
+internal fun mcpDisplayToolName(providerToolName: String): String {
+    val withoutPrefix = providerToolName.removePrefix(MCP_TOOL_PREFIX)
+    val hasServerKey = withoutPrefix.length > MCP_TOOL_SERVER_KEY_LENGTH + 2 &&
+        withoutPrefix.substring(MCP_TOOL_SERVER_KEY_LENGTH).startsWith("__") &&
+        withoutPrefix.take(MCP_TOOL_SERVER_KEY_LENGTH).all { it in '0'..'9' || it in 'a'..'f' }
+    return if (providerToolName.startsWith(MCP_TOOL_PREFIX) && hasServerKey) {
+        withoutPrefix.substring(MCP_TOOL_SERVER_KEY_LENGTH + 2)
+    } else {
+        withoutPrefix
+    }
+}
 
 class McpManager(
     private val settingsStore: SettingsStore,
@@ -95,7 +114,9 @@ class McpManager(
                 .collect { mcpServerConfigs ->
                     runCatching {
                         Log.i(TAG, "update configs: $mcpServerConfigs")
-                        val newConfigs = mcpServerConfigs.filter { it.commonOptions.enable }
+                        val newConfigs = mcpServerConfigs.filter {
+                            it.commonOptions.enable && it.commonOptions.name.isNotBlank()
+                        }
                         val currentConfigs = clients.keys.toList()
                         val (toAdd, toRemove) = currentConfigs.checkDifferent(
                             other = newConfigs,
@@ -123,7 +144,7 @@ class McpManager(
         return clients.entries.find { it.key.id == config.id }?.value
     }
 
-    fun getAllAvailableTools(): List<Pair<Uuid, McpTool>> {
+    fun getAllAvailableTools(): List<Triple<Uuid, String, McpTool>> {
         val settings = settingsStore.settingsFlow.value
         return settings.mcpServers
             .filter {
@@ -132,7 +153,7 @@ class McpManager(
             .flatMap { server ->
                 server.commonOptions.tools
                     .filter { tool -> tool.enable }
-                    .map { tool -> server.id to tool }
+                    .map { tool -> Triple(server.id, server.commonOptions.name, tool) }
             }
     }
 

--- a/app/src/main/java/com/eterultimate/eteruee/service/ChatService.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/service/ChatService.kt
@@ -55,6 +55,8 @@ import com.eterultimate.eteruee.RouteActivity
 import com.eterultimate.eteruee.data.ai.GenerationChunk
 import com.eterultimate.eteruee.data.ai.GenerationHandler
 import com.eterultimate.eteruee.data.ai.mcp.McpManager
+import com.eterultimate.eteruee.data.ai.mcp.mcpDisplayToolName
+import com.eterultimate.eteruee.data.ai.mcp.mcpProviderToolName
 import com.eterultimate.eteruee.data.ai.tools.LocalTools
 import com.eterultimate.eteruee.data.ai.tools.createSearchTools
 import com.eterultimate.eteruee.data.ai.tools.createSkillTools
@@ -559,10 +561,10 @@ class ChatService(
                             )
                         )
                     }
-                    mcpManager.getAllAvailableTools().forEach { (serverId, tool) ->
+                    mcpManager.getAllAvailableTools().forEach { (serverId, _, tool) ->
                         add(
                             Tool(
-                                name = "mcp__" + tool.name,
+                                name = mcpProviderToolName(serverId, tool.name),
                                 description = tool.description ?: "",
                                 parameters = { tool.inputSchema },
                                 needsApproval = tool.needsApproval,
@@ -734,7 +736,7 @@ class ChatService(
                         prompt = settings.titlePrompt.applyPlaceholders(
                             "locale" to Locale.getDefault().displayName,
                             "content" to conversation.currentMessages
-                                .takeLast(4).joinToString("\n\n") { it.summaryAsText() })
+                                .takeLast(4).joinToString("\n\n") { it.summaryAsText(maxLength = 500) })
                     ),
                 ),
                 params = backgroundTextGenerationParams(model),
@@ -781,7 +783,7 @@ class ChatService(
                         settings.suggestionPrompt.applyPlaceholders(
                             "locale" to Locale.getDefault().displayName,
                             "content" to conversation.currentMessages
-                                .takeLast(8).joinToString("\n\n") { it.summaryAsText() }),
+                                .takeLast(8).joinToString("\n\n") { it.summaryAsText(maxLength = 500) }),
                     )
                 ),
                 params = backgroundTextGenerationParams(model),
@@ -851,7 +853,7 @@ class ChatService(
         }
 
         suspend fun compressMessages(messages: List<UIMessage>): String {
-            val contentToCompress = messages.joinToString("\n\n") { it.summaryAsText() }
+            val contentToCompress = messages.joinToString("\n\n") { it.summaryAsText(maxLength = 2000) }
             val prompt = settings.compressPrompt.applyPlaceholders(
                 "content" to contentToCompress,
                 "target_tokens" to targetTokens.toString(),
@@ -952,7 +954,7 @@ class ChatService(
         return when {
             // 正在执行工具
             lastTool != null && !lastTool.isExecuted -> {
-                val toolName = lastTool.toolName.removePrefix("mcp__")
+                val toolName = mcpDisplayToolName(lastTool.toolName)
                 Triple(
                     context.getString(R.string.notification_live_update_chip_tool),
                     context.getString(R.string.notification_live_update_tool, toolName),

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingMcpPage.kt
@@ -237,7 +237,9 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
             onDismiss = { showImportDialog = false },
             onImport = { newConfigs ->
                 val existingIds = mcpConfigs.map { it.commonOptions.name }.toSet()
-                val toAdd = newConfigs.filter { it.commonOptions.name !in existingIds }
+                val toAdd = newConfigs.filter {
+                    it.commonOptions.name.isNotBlank() && it.commonOptions.name !in existingIds
+                }
                 vm.updateSettings(settings.copy(mcpServers = mcpConfigs + toAdd))
                 showImportDialog = false
             }

--- a/app/src/test/java/com/eterultimate/eteruee/data/ai/mcp/McpToolNameTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/data/ai/mcp/McpToolNameTest.kt
@@ -1,0 +1,31 @@
+package com.eterultimate.eteruee.data.ai.mcp
+
+import kotlin.uuid.Uuid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class McpToolNameTest {
+    @Test
+    fun `provider tool name includes server key to avoid duplicate MCP tool names`() {
+        val firstServerId = Uuid.parse("11111111-1111-1111-1111-111111111111")
+        val secondServerId = Uuid.parse("22222222-2222-2222-2222-222222222222")
+
+        val firstName = mcpProviderToolName(firstServerId, "search")
+        val secondName = mcpProviderToolName(secondServerId, "search")
+
+        assertEquals("mcp__111111111111__search", firstName)
+        assertEquals("mcp__222222222222__search", secondName)
+        assertNotEquals(firstName, secondName)
+    }
+
+    @Test
+    fun `display tool name strips MCP server key when present`() {
+        assertEquals("search", mcpDisplayToolName("mcp__111111111111__search"))
+    }
+
+    @Test
+    fun `display tool name keeps legacy MCP tool names readable`() {
+        assertEquals("search", mcpDisplayToolName("mcp__search"))
+    }
+}


### PR DESCRIPTION
## Summary
- Port RikkaHub `301450f46` / PR #1300 safeguard by truncating `summaryAsText(maxLength)` for title, suggestion, and compression prompts so large text payloads do not explode background prompt size.
- Port RikkaHub `37bb65e5c` / PR #1290 by ignoring blank MCP server names while connecting/importing configs.
- Port RikkaHub `80450cb2d` / issue #1311 intent by namespacing MCP provider tool names per server to avoid duplicate tool-name failures when multiple MCP servers expose the same tool. This uses a provider-safe UUID-derived server key instead of the user-visible server name, avoiding a new failure mode for existing non-ASCII or spaced server names.

## Evidence reviewed
- `rikkahub/rikkahub` commits: `301450f46`, `37bb65e5c`, `80450cb2d`, plus follow-up MCP-name validation commits `928a0d4ae` and `0408e293`.
- `rikkahub/rikkahub` issue #1311: Gemini 400 with duplicate MCP tool names.
- `Darkatse/TauriTavern` PRs #91, #92, #95 and recent issues were scanned; their changes target Tauri/windowed-chat bridge paths without a directly matching EterUee Android roleplay surface, so no roleplay patch was included.

## Validation
- `./gradlew :app:testDebugUnitTest --tests com.eterultimate.eteruee.data.ai.mcp.McpToolNameTest`
- `./gradlew :ai:testDebugUnitTest`
- `./gradlew :app:compileDebugKotlin`

## Summary by Sourcery

Port upstream safeguards for MCP tool naming and background prompt sizing to prevent collisions and oversized prompts.

Bug Fixes:
- Prevent duplicate MCP tool name collisions across servers by namespacing tool identifiers per server and preserving readable display names.
- Ignore MCP server configs with blank names when importing or enabling servers to avoid invalid configurations.
- Limit the size of generated title, suggestion, and compression prompts by truncating message summaries used in background generations.

Tests:
- Add unit tests for MCP provider/display tool name handling and for truncated message summaries to validate the new safeguards.