### PR TITLE
fix: port upstream stability safeguards

### DIFF
--- a/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -354,6 +354,10 @@ class ChatCompletionsAPI(
                         }
                     }
 
+                    host.matchesHostOrSubdomain("aiping.cn") -> {
+                        put("enable_thinking", level.isEnabled)
+                    }
+
                     host.matchesHostOrSubdomain("open.bigmodel.cn") -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")

--- a/ai/src/test/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -544,6 +544,25 @@ class ChatCompletionsAPIMessageTest {
         assertTrue(!request.containsKey("reasoning_effort"))
     }
 
+    @Test
+    fun `buildChatCompletionRequest should route aiping reasoning params`() {
+        val reasoningModel = Model(
+            modelId = "deepseek-v4",
+            abilities = listOf(ModelAbility.REASONING)
+        )
+
+        val request = invokeBuildChatCompletionRequest(
+            providerSetting = ProviderSetting.OpenAI(
+                baseUrl = "https://api.aiping.cn/v1"
+            ),
+            model = reasoningModel,
+            reasoningLevel = ReasoningLevel.OFF
+        )
+
+        assertEquals("false", request["enable_thinking"]?.jsonPrimitive?.content)
+        assertTrue(!request.containsKey("reasoning_effort"))
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(

--- a/app/src/main/java/com/eterultimate/eteruee/data/files/SkillManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/files/SkillManager.kt
@@ -46,11 +46,11 @@ class SkillManager(
     }
 
     fun saveSkill(name: String, content: String): SkillMetadata? {
+        if (!saveSkillBinaryFilesAtomically(name, mapOf("SKILL.md" to content.toByteArray()))) {
+            return null
+        }
         val skillDir = resolveSkillDir(name) ?: return null
-        skillDir.mkdirs()
-        val skillFile = skillDir.resolve("SKILL.md")
-        skillFile.writeText(content)
-        return parseSkillFile(skillFile, skillDir)
+        return parseSkillFile(skillDir.resolve("SKILL.md"), skillDir)
     }
 
     suspend fun deleteSkill(name: String): Boolean = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessage.kt
@@ -372,7 +372,7 @@ private fun MessagePartsBlock(
             is MessagePartBlock.ContentBlock -> key(block.index) {
                 when (val part = block.part) {
                     is UIMessagePart.Text -> {
-                        SelectionContainer {
+                        val textContent = @Composable {
                             if (role == MessageRole.USER) {
                                 Surface(
                                     modifier = Modifier.animateContentSize(),
@@ -421,6 +421,13 @@ private fun MessagePartsBlock(
                                             .animateContentSize()
                                     )
                                 }
+                            }
+                        }
+                        if (loading) {
+                            textContent()
+                        } else {
+                            SelectionContainer {
+                                textContent()
                             }
                         }
                     }

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessageReasoning.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessageReasoning.kt
@@ -126,6 +126,7 @@ private fun ReasoningContent(
     expandState: ReasoningCardState,
     scrollState: ScrollState,
     fadeHeight: Float,
+    loading: Boolean,
 ) {
     val isPreview = expandState == ReasoningCardState.Preview
     Column(
@@ -162,7 +163,7 @@ private fun ReasoningContent(
                 }
             }
     ) {
-        SelectionContainer {
+        val reasoningContent = @Composable {
             MarkdownBlock(
                 content = reasoning.reasoning.replaceRegexes(
                     assistant = assistant,
@@ -172,6 +173,13 @@ private fun ReasoningContent(
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.fillMaxSize(),
             )
+        }
+        if (loading) {
+            reasoningContent()
+        } else {
+            SelectionContainer {
+                reasoningContent()
+            }
         }
     }
 }
@@ -233,6 +241,7 @@ fun ChainOfThoughtScope.ChatMessageReasoningStep(
                 expandState = state.expandState,
                 scrollState = state.scrollState,
                 fadeHeight = fadeHeight,
+                loading = loading,
             )
         },
     )

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/chat/ChatPage.kt
@@ -120,6 +120,12 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
     val isBigScreen =
         windowAdaptiveInfo.width > windowAdaptiveInfo.height && windowAdaptiveInfo.width >= 1100.dp
 
+    LaunchedEffect(isBigScreen) {
+        if (isBigScreen && drawerState.isOpen) {
+            drawerState.close()
+        }
+    }
+
     val inputState = vm.inputState
 
     // 初始化输入状态（处理传入的 files 和 text 参数）

--- a/app/src/main/java/com/eterultimate/eteruee/utils/ComposeExt.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/utils/ComposeExt.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 
 @Composable
 operator fun PaddingValues.plus(other: PaddingValues): PaddingValues {
@@ -40,7 +41,7 @@ fun Dp.toSp(): TextUnit = with(LocalDensity.current) {
 
 @Composable
 fun TextUnit.toDp(): Dp = with(LocalDensity.current) {
-    this@toDp.toDp()
+    if (this@toDp.isSp) this@toDp.toDp() else 0.dp
 }
 
 fun TextFieldState.insertAtCursor(text: String) {


### PR DESCRIPTION
## Evidence
- rikkahub/rikkahub@7973bbf8c: `TextUnit.toDp` now guards non-Sp units to avoid Compose `Only Sp can convert to Px` crashes.
- rikkahub/rikkahub@b8786a5c9: disables `SelectionContainer` during streaming to avoid Compose selectable-list `ConcurrentModificationException`.
- rikkahub/rikkahub@d3f5cd018 / issue #1327: saves skills through atomic staging + rename instead of direct `mkdirs` + `writeText`.
- rikkahub/rikkahub@fca33136e / issue #1304: closes modal drawer when switching into permanent-drawer tablet layout.
- rikkahub/rikkahub@a92b31947 / issue #1334: routes `aiping.cn` reasoning toggle as `enable_thinking`.

## Changes
- Hardened shared Compose `TextUnit.toDp()` against Em/Unspecified units.
- Temporarily bypassed message/reasoning `SelectionContainer` while assistant output is still streaming.
- Reused existing atomic skill package save path for `saveSkill()`.
- Reset chat drawer state when entering big-screen layout.
- Added `aiping.cn` reasoning parameter support and a request-body unit test.

## Validation
- `./gradlew :ai:testDebugUnitTest --tests com.eterultimate.eteruee.ai.provider.providers.openai.ChatCompletionsAPIMessageTest`
- `./gradlew --no-daemon --max-workers=1 '-Dkotlin.compiler.execution.strategy=in-process' '-Dkotlin.incremental=false' :app:compileDebugKotlin`

## Notes
- Darkatse/TauriTavern scan: recent `dev` PR #95 concerns Tauri bridge input validation and recent issue #96 concerns visual novel mode display. EterUee has no matching Tauri bridge or visual-novel roleplay surface, so no roleplay patch was applied from that source.
- Repo labels `codex` and `codex-automation` are not present, so labels were not added.

## Summary by Sourcery

Improve stability of chat UI, skills persistence, and provider-specific reasoning parameter handling.

Bug Fixes:
- Prevent crashes from converting non-Sp TextUnit values to Dp in shared Compose utilities.
- Disable text selection containers while messages and reasoning content are streaming to avoid concurrent modification issues.
- Save skills using the existing atomic file-writing path instead of direct directory and file writes to avoid corruption or partial writes.
- Automatically close the modal chat drawer when switching into the big-screen permanent-drawer layout to prevent inconsistent UI state.

Enhancements:
- Add provider-specific routing of aiping.cn reasoning settings via the enable_thinking parameter.
- Extend OpenAI chat completion request tests to cover aiping.cn reasoning parameter behavior.

Tests:
- Add a unit test asserting that aiping.cn chat completion requests correctly map reasoning settings to enable_thinking without setting reasoning_effort.