### PR TITLE
fix: port zstd apk exclusion and base64 summary stripping from stale branches

### DIFF
--- a/ai/src/main/java/com/eterultimate/eteruee/ai/ui/Message.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/ui/Message.kt
@@ -165,7 +165,7 @@ data class UIMessage(
     fun summaryAsText(maxLength: Int = Int.MAX_VALUE): String {
         val text = "[${role.name}]: " + parts.joinToString(separator = "\n") { part ->
             when (part) {
-                is UIMessagePart.Text -> part.text
+                is UIMessagePart.Text -> part.text.stripInlineDataUrlsForSummary()
                 else -> ""
             }
         }
@@ -224,6 +224,12 @@ data class UIMessage(
         )
     }
 }
+
+private fun String.stripInlineDataUrlsForSummary(): String =
+    replace(INLINE_DATA_URL_REGEX, "[omitted inline data]")
+
+private val INLINE_DATA_URL_REGEX =
+    Regex("""data:[\w.+-]+/[\w.+-]+(?:;[\w.+-]+=[\w.+-]+)*;base64,[A-Za-z0-9+/=_-]+""")
 
 /**
  * 处理MessageChunk合并

--- a/ai/src/test/java/com/eterultimate/eteruee/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/com/eterultimate/eteruee/ai/ui/MessageTest.kt
@@ -195,6 +195,23 @@ class MessageTest {
         assertEquals("[USER]: he...", message.summaryAsText(maxLength = 10))
     }
 
+    @Test
+    fun `summaryAsText should omit inline base64 data urls from text parts`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Text(
+                    "Generated image: data:image/png;base64,AAAABBBBCCCC keep this caption"
+                )
+            )
+        )
+
+        val summary = message.summaryAsText()
+
+        assertEquals("[ASSISTANT]: Generated image: [omitted inline data] keep this caption", summary)
+        assertFalse(summary.contains("AAAABBBBCCCC"))
+    }
+
     // ==================== migrateToolMessages Tests ====================
 
     @Test

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,6 +182,15 @@ android {
         jniLibs {
             useLegacyPackaging = true
         }
+        resources {
+            excludes += setOf(
+                "aix/**",
+                "darwin/**",
+                "freebsd/**",
+                "linux/**",
+                "win/**",
+            )
+        }
     }
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
## 背景

从旧分支 `codex/upgrade-llm-runtime-shell` 和本地 WIP 补丁审查中确认，有两处修复未随功能合并进入 main，本 PR 补齐：

## 变更

### 1. fix: exclude desktop zstd resources from android apk (22ea19da7)

main 引入了 `libs.zstd.jni` 依赖（`LinuxEnvironmentManager` 使用），但其 jar 内含各桌面平台的原生库资源目录，未排除会被打进 APK。来源为旧分支提交 b7559411a，在 `packaging` 块增加 `resources.excludes`（aix/darwin/freebsd/linux/win），zstd-jni 的 android 原生库不受影响。

### 2. fix: strip inline base64 data urls from message summaries (f23773f3e)

`UIMessage.summaryAsText()` 被 `ChatService` 的记忆生成与上下文压缩（maxLength 500–2000）调用，Text part 中的 base64 data URL 会撑爆这些 prompt。增加 `stripInlineDataUrlsForSummary()`，将 `data:<mime>;base64,<payload>` 替换为 `[omitted inline data]`，并新增对应单元测试（移植自本地 WIP 补丁）。

## 验证

- `./gradlew :ai:testDebugUnitTest --tests "com.eterultimate.eteruee.ai.ui.MessageTest"` 通过（BUILD SUCCESSFUL，Gradle 9.7.1）
- 构建过程中全部模块配置成功，`app/build.gradle.kts` 的 Packaging DSL 语法已验证

## 备注

- 两个文件改动均为字节级编辑（保留 CRLF 工作区字节），diff 无 EOL churn。
- 相关分支 `codex/upgrade-llm-runtime-shell` 的其余内容（linux runtime / plugin 功能）已确认在 main 中存在且更新，分支已清理。

## Summary by Sourcery

Prevent unnecessary desktop zstd resources and inline base64 payloads from being included in Android artifacts and message summaries.

Bug Fixes:
- Prevent inline base64 data URLs from inflating generated message summaries by replacing their payloads with an omission marker.
- Exclude desktop zstd native resources from Android APK packaging while retaining Android native libraries.

Tests:
- Add coverage verifying that inline base64 data URLs are omitted from message summaries.