### PR TITLE
sync: rikkahub 08-28~09-04 修复与功能移植 + ask_user 空白卡片修复

### DIFF
--- a/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -88,6 +88,11 @@ class ChatCompletionsAPI(
             .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
             .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}")
             .configureReferHeaders(providerSetting.baseUrl)
+            .apply {
+                if (providerSetting.baseUrl.toHttpUrl().host == "opencode.ai") {
+                    params.sessionId?.let { header("x-opencode-session", it) }
+                }
+            }
             .build()
 
         Log.i(TAG, "generateText: ${json.encodeToString(requestBody)}")
@@ -146,6 +151,11 @@ class ChatCompletionsAPI(
             .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}")
             .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
+            .apply {
+                if (providerSetting.baseUrl.toHttpUrl().host == "opencode.ai") {
+                    params.sessionId?.let { header("x-opencode-session", it) }
+                }
+            }
             .build()
 
         Log.i(TAG, "streamText: ${json.encodeToString(requestBody)}")

--- a/ai/src/main/java/com/eterultimate/eteruee/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/com/eterultimate/eteruee/ai/registry/ModelRegistry.kt
@@ -87,6 +87,12 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val GPT_6 = defineModel {
+        tokens("gpt", "6")
+        visionInput()
+        toolReasoningAbility()
+    }
+
     private val GEMINI_20_FLASH = defineModel {
         tokens("gemini", "2", "0", "flash")
         visionInput()
@@ -588,6 +594,7 @@ object ModelRegistry {
         GPT_5_4_NANO,
         GPT_5_5,
         GPT_5_6,
+        GPT_6,
         GEMINI_20_FLASH,
         GEMINI_2_5_FLASH,
         GEMINI_2_5_PRO,

--- a/app/src/androidTest/java/com/eterultimate/eteruee/data/sync/BackupManagerTest.kt
+++ b/app/src/androidTest/java/com/eterultimate/eteruee/data/sync/BackupManagerTest.kt
@@ -1,0 +1,138 @@
+package com.eterultimate.eteruee.data.sync
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.db.AppDatabase
+import com.eterultimate.eteruee.AppScope
+import com.eterultimate.eteruee.data.db.AppDatabaseFactory
+import com.eterultimate.eteruee.utils.JsonInstant
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class BackupManagerTest {
+    private lateinit var directory: File
+    private lateinit var context: Context
+    private lateinit var liveDatabase: AppDatabase
+    private lateinit var manager: BackupManager
+    private lateinit var settingsScope: CoroutineScope
+
+    @Before fun setUp() {
+        val app = InstrumentationRegistry.getInstrumentation().targetContext
+        directory = Files.createTempDirectory(app.cacheDir.toPath(), "backup-manager-test-").toFile()
+        context = object : ContextWrapper(app) {
+            override fun getApplicationContext(): Context = this
+            override fun getFilesDir() = File(directory, "files").apply { mkdirs() }
+            override fun getCacheDir() = File(directory, "cache").apply { mkdirs() }
+            override fun getNoBackupFilesDir() = File(directory, "no-backup").apply { mkdirs() }
+            override fun getDatabasePath(name: String): File = if (File(name).isAbsolute) File(name)
+                else File(directory, "databases/$name").also { it.parentFile!!.mkdirs() }
+        }
+        settingsScope = CoroutineScope(Dispatchers.IO)
+        liveDatabase = AppDatabaseFactory.create(context)
+        liveDatabase.openHelper.writableDatabase.execSQL("CREATE TABLE backup_probe (text TEXT)")
+        liveDatabase.openHelper.writableDatabase.execSQL("INSERT INTO backup_probe VALUES ('live')")
+        manager = BackupManager(context, liveDatabase, SettingsStore(context, AppScope()), JsonInstant)
+    }
+
+    @After fun tearDown() {
+        liveDatabase.close()
+        settingsScope.cancel()
+        directory.deleteRecursively()
+    }
+
+    @Test fun oldArchiveIgnoresShmAndLeavesLiveDatabaseUntouchedUntilStartup() = runBlocking {
+        val source = File(directory, "source")
+        val archive = File(directory, "legacy.zip")
+        withRoom(source) { room ->
+            val db = room.openHelper.writableDatabase
+            db.execSQL("CREATE TABLE backup_probe (text TEXT)")
+            DatabaseBackup.checkpoint(db)
+            db.query("PRAGMA wal_autocheckpoint=0").use { assertTrue(it.moveToFirst()) }
+            db.execSQL("INSERT INTO backup_probe VALUES ('archived')")
+            ZipOutputStream(archive.outputStream()).use { zip ->
+                addFile(zip, DatabaseBackup.ARCHIVE_DATABASE, source)
+                addFile(zip, DatabaseBackup.WAL, File(source.path + "-wal"))
+                zip.putNextEntry(ZipEntry(DatabaseBackup.SHM))
+                zip.write("deliberately invalid SHM".toByteArray())
+                zip.closeEntry()
+            }
+        }
+        manager.stageRestore(archive, includeDatabase = true, includeFiles = false)
+        assertEquals("live", probe(liveDatabase))
+        val staged = File(context.noBackupFilesDir, "backup-restore/pending/payload/database/rikka_hub")
+        assertTrue(staged.isFile)
+        assertFalse(File(staged.path + "-wal").exists())
+        assertFalse(File(staged.path + "-shm").exists())
+        liveDatabase.close()
+        BackupManager.applyPendingRestore(context, JsonInstant)
+        liveDatabase = AppDatabaseFactory.create(context)
+        assertEquals("archived", probe(liveDatabase))
+        ZipFile(archive).use { assertTrue(it.getEntry(DatabaseBackup.SHM) != null) }
+    }
+
+    @Test fun newArchiveContainsStandaloneDatabaseAndNoWalOrShm() = runBlocking {
+        val archive = manager.createBackup(includeDatabase = true, includeFiles = false)
+        ZipFile(archive).use { zip ->
+            assertTrue(zip.getEntry("settings.json") != null)
+            assertTrue(zip.getEntry(DatabaseBackup.ARCHIVE_DATABASE) != null)
+            assertEquals(null, zip.getEntry(DatabaseBackup.WAL))
+            assertEquals(null, zip.getEntry(DatabaseBackup.SHM))
+        }
+        manager.stageRestore(archive, includeDatabase = true, includeFiles = false)
+        assertEquals("live", probe(liveDatabase))
+    }
+
+    @Test fun unsupportedSchemaIsRejectedBeforePublishing() = runBlocking {
+        val future = File(directory, "future")
+        withRoom(future) {
+            it.openHelper.writableDatabase.version = 9999
+        }
+        val archive = File(directory, "future.zip")
+        ZipOutputStream(archive.outputStream()).use { addFile(it, DatabaseBackup.ARCHIVE_DATABASE, future) }
+        var failed = false
+        try {
+            manager.stageRestore(archive, includeDatabase = true, includeFiles = false)
+        } catch (_: Exception) {
+            failed = true
+        }
+        assertTrue(failed)
+        assertFalse(File(context.noBackupFilesDir, "backup-restore/pending").exists())
+        assertEquals("live", probe(liveDatabase))
+    }
+
+    private fun probe(database: AppDatabase): String = database.openHelper.readableDatabase
+        .query("SELECT text FROM backup_probe").use { check(it.moveToFirst()); it.getString(0) }
+
+    private fun addFile(zip: ZipOutputStream, name: String, file: File) {
+        zip.putNextEntry(ZipEntry(name))
+        file.inputStream().use { it.copyTo(zip) }
+        zip.closeEntry()
+    }
+
+    private fun <T> withRoom(file: File, block: (AppDatabase) -> T): T {
+        val room = AppDatabaseFactory.create(context, file.path)
+        return try {
+            block(room)
+        } finally {
+            room.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/eterultimate/eteruee/data/sync/DatabaseBackupTest.kt
+++ b/app/src/androidTest/java/com/eterultimate/eteruee/data/sync/DatabaseBackupTest.kt
@@ -1,0 +1,89 @@
+package com.eterultimate.eteruee.data.sync
+
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.nio.file.Files
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseBackupTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var directory: File
+
+    @Before fun setUp() {
+        directory = Files.createTempDirectory(context.cacheDir.toPath(), "database-backup-test-").toFile()
+    }
+
+    @After fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    private fun open(file: File): SQLiteDatabase = SQLiteDatabase.openDatabase(
+        file.path,
+        null,
+        SQLiteDatabase.CREATE_IF_NECESSARY,
+    )
+
+    private fun createWalDatabase(file: File): SQLiteDatabase = open(file).apply {
+        enableWriteAheadLogging()
+        query("PRAGMA wal_autocheckpoint=0").use { assertTrue(it.moveToFirst()) }
+        execSQL("CREATE TABLE messages (id INTEGER PRIMARY KEY, text TEXT)")
+        query("PRAGMA wal_checkpoint(TRUNCATE)").use { assertTrue(it.moveToFirst()) }
+        execSQL("INSERT INTO messages(text) VALUES ('committed only in WAL')")
+        assertTrue(File(file.path + "-wal").length() > 0)
+    }
+
+    @Test fun legacyWalIsMergedWithoutShmAndWithoutChangingOriginalArchiveFiles() {
+        val source = File(directory, "source")
+        val staged = File(directory, "rikka_hub")
+        createWalDatabase(source).use {
+            source.copyTo(staged)
+            File(source.path + "-wal").copyTo(File(staged.path + "-wal"))
+        }
+        DatabaseBackup.normalize(context, staged)
+        assertFalse(File(staged.path + "-wal").exists())
+        assertFalse(File(staged.path + "-shm").exists())
+        open(staged).use {
+            assertEquals("committed only in WAL", it.stringForQuery("SELECT text FROM messages", null))
+        }
+    }
+
+    @Test fun snapshotContainsWalCommitsAndFtsTablesAndNeedsNoSidecars() {
+        val source = File(directory, "source")
+        val snapshot = File(directory, "snapshot")
+        createWalDatabase(source).use {
+            it.execSQL("CREATE VIRTUAL TABLE search USING fts5(text, tokenize='unicode61')")
+            it.execSQL("INSERT INTO search(text) VALUES ('hello backup')")
+            DatabaseBackup.createSnapshot(it, snapshot)
+            // Subsequent writes must not appear in the already-created snapshot.
+            it.execSQL("INSERT INTO messages(text) VALUES ('after snapshot')")
+        }
+        assertFalse(File(snapshot.path + "-wal").exists())
+        assertFalse(File(snapshot.path + "-shm").exists())
+        DatabaseBackup.normalize(context, snapshot)
+        open(snapshot).use {
+            assertEquals(1L, it.longForQuery("SELECT count(*) FROM messages", null))
+            assertEquals(1L, it.longForQuery("SELECT count(*) FROM search WHERE search MATCH 'hello'", null))
+        }
+    }
+
+    @Test fun corruptDatabaseIsRejected() {
+        val file = File(directory, "invalid")
+        file.writeText("not a SQLite database")
+        var failed = false
+        try {
+            DatabaseBackup.normalize(context, file)
+        } catch (_: Exception) {
+            failed = true
+        }
+        assertTrue("Corrupt backup must not be published", failed)
+    }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/EterUeeApp.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/EterUeeApp.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import com.eterultimate.eteruee.di.appModule
 import com.eterultimate.eteruee.di.dataSourceModule
 import com.eterultimate.eteruee.di.repositoryModule
@@ -27,6 +28,9 @@ import com.eterultimate.eteruee.di.viewModelModule
 import com.eterultimate.eteruee.roleplay.di.roleplayModule
 import com.eterultimate.eteruee.data.files.FilesManager
 import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.sync.BackupManager
+import com.eterultimate.eteruee.data.sync.RestoreFailedException
+import com.eterultimate.eteruee.utils.JsonInstant
 import com.eterultimate.eteruee.runtime.NativeRuntime
 import com.eterultimate.eteruee.service.WebServerService
 import com.eterultimate.eteruee.utils.CrashHandler
@@ -49,6 +53,18 @@ const val WEB_SERVER_NOTIFICATION_CHANNEL_ID = "web_server"
 class EterUeeApp : Application() {
     override fun onCreate() {
         super.onCreate()
+        // Restore files and settings before eager Koin singletons or workers can access them.
+        try {
+            val restored = runBlocking(Dispatchers.IO) {
+                BackupManager.applyPendingRestore(this@EterUeeApp, JsonInstant)
+            }
+            if (restored) {
+                android.widget.Toast.makeText(this, R.string.backup_page_restore_success, android.widget.Toast.LENGTH_LONG).show()
+            }
+        } catch (e: RestoreFailedException) {
+            android.util.Log.e(TAG, "Backup restore rolled back", e)
+            android.widget.Toast.makeText(this, "备份恢复失败，已保留原数据。请重新导入备份。", android.widget.Toast.LENGTH_LONG).show()
+        }
         startKoin {
             androidLogger()
             androidContext(this@EterUeeApp)

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/GenerationHandler.kt
@@ -485,11 +485,15 @@ class GenerationHandler(
                             error = error,
                             retryCount = retryCount,
                             processingStatus = processingStatus,
+                            enabled = settings.networkSetting.enableAutoRetry,
                         )
                     }
                 }
             } else {
-                val chunk = executeProviderRequestWithRetry(processingStatus) {
+                val chunk = executeProviderRequestWithRetry(
+                    processingStatus = processingStatus,
+                    enabled = settings.networkSetting.enableAutoRetry,
+                ) {
                     providerImpl.generateText(
                         providerSetting = provider,
                         messages = internalMessages,
@@ -517,6 +521,7 @@ class GenerationHandler(
 
     private suspend fun <T> executeProviderRequestWithRetry(
         processingStatus: MutableStateFlow<String?>,
+        enabled: Boolean,
         block: suspend () -> T,
     ): T {
         var retryCount = 0
@@ -528,6 +533,7 @@ class GenerationHandler(
                     error = error,
                     retryCount = retryCount,
                     processingStatus = processingStatus,
+                    enabled = enabled,
                 )
             }
         }
@@ -537,11 +543,12 @@ class GenerationHandler(
         error: Throwable,
         retryCount: Int,
         processingStatus: MutableStateFlow<String?>,
+        enabled: Boolean,
     ): Int {
         // 用户主动停止生成时，底层连接也可能以 IOException("canceled") 收尾；
         // 先检查协程状态，确保取消不会被当作网络波动重新拉起。
         currentCoroutineContext().ensureActive()
-        if (error !is IOException || retryCount >= MAX_PROVIDER_NETWORK_RETRIES) {
+        if (!enabled || error !is IOException || retryCount >= MAX_PROVIDER_NETWORK_RETRIES) {
             throw error
         }
 

--- a/app/src/main/java/com/eterultimate/eteruee/data/ai/mcp/McpOAuthCoordinator.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/ai/mcp/McpOAuthCoordinator.kt
@@ -118,8 +118,7 @@ internal class McpOAuthCoordinator(
     }
 
     suspend fun needsAuthorization(config: McpServerConfig, error: Throwable): Boolean {
-        if (!looksUnauthorized(error)) return false
-        if (config.commonOptions.oauth?.enabled == true) return true
+        if (looksUnauthorized(error) && config.commonOptions.oauth?.enabled == true) return true
         if (config.commonOptions.headers.any { it.first.equals("Authorization", ignoreCase = true) }) {
             return false
         }

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/DefaultProviders.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/DefaultProviders.kt
@@ -138,11 +138,6 @@ val DEFAULT_PROVIDERS = listOf(
                 """.trimIndent()
             )
         },
-        balanceOption = BalanceOption(
-            enabled = true,
-            apiPath = "/user/info",
-            resultPath = "data.totalBalance",
-        ),
     ),
     ProviderSetting.OpenAI(
         id = Uuid.parse("f099ad5b-ef03-446d-8e78-7e36787f780b"),

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
@@ -2,7 +2,9 @@ package com.eterultimate.eteruee.data.datastore
 
 import android.content.Context
 import android.util.Log
+import androidx.datastore.core.DataStore
 import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -159,6 +161,76 @@ class SettingsStore(
 
         // 赞助提醒
         val SPONSOR_ALERT_DISMISSED_AT = intPreferencesKey("sponsor_alert_dismissed_at")
+
+        // Uses the same DataStore singleton without starting settings flows or requiring Koin.
+        internal suspend fun restoreBeforeInitialization(context: Context, settings: Settings) {
+            require(!settings.init) { "Cannot restore uninitialized settings" }
+            persistSettings(context.settingsStore, settings)
+        }
+
+        private suspend fun persistSettings(dataStore: DataStore<Preferences>, settings: Settings) {
+        dataStore.edit { preferences ->
+            preferences[DYNAMIC_COLOR] = settings.dynamicColor
+            preferences[THEME_ID] = settings.themeId
+            preferences[CUSTOM_THEMES] = JsonInstant.encodeToString(settings.customThemes)
+            preferences[DEVELOPER_MODE] = settings.developerMode
+            preferences[DISPLAY_SETTING] = JsonInstant.encodeToString(settings.displaySetting)
+
+            preferences[ENABLE_WEB_SEARCH] = settings.enableWebSearch
+            preferences[ENABLE_SUBAGENT] = settings.enableSubagent
+            preferences[FAVORITE_MODELS] = JsonInstant.encodeToString(settings.favoriteModels)
+            preferences[SELECT_MODEL] = settings.chatModelId.toString()
+            preferences[TITLE_MODEL] = settings.titleModelId.toString()
+            preferences[TRANSLATE_MODEL] = settings.translateModeId.toString()
+            preferences[SUGGESTION_MODEL] = settings.suggestionModelId.toString()
+            preferences[IMAGE_GENERATION_MODEL] = settings.imageGenerationModelId.toString()
+            preferences[VIDEO_GENERATION_MODEL] = settings.videoGenerationModelId.toString()
+
+            preferences[TITLE_PROMPT] = settings.titlePrompt
+            preferences[TRANSLATION_PROMPT] = settings.translatePrompt
+            preferences[TRANSLATE_THINKING_BUDGET] = settings.translateThinkingBudget
+            preferences[SUGGESTION_PROMPT] = settings.suggestionPrompt
+            preferences[OCR_MODEL] = settings.ocrModelId.toString()
+            preferences[OCR_PROMPT] = settings.ocrPrompt
+            preferences[COMPRESS_MODEL] = settings.compressModelId.toString()
+            preferences[COMPRESS_PROMPT] = settings.compressPrompt
+
+            preferences[PROVIDERS] = JsonInstant.encodeToString(settings.providers)
+
+            preferences[ASSISTANTS] = JsonInstant.encodeToString(settings.assistants)
+            preferences[SELECT_ASSISTANT] = settings.assistantId.toString()
+            preferences[ASSISTANT_TAGS] = JsonInstant.encodeToString(settings.assistantTags)
+
+            preferences[SEARCH_SERVICES] = JsonInstant.encodeToString(settings.searchServices)
+            preferences[SEARCH_COMMON] = JsonInstant.encodeToString(settings.searchCommonOptions)
+            preferences[SEARCH_SELECTED] = settings.searchServiceSelected.coerceIn(0, settings.searchServices.size - 1)
+
+            preferences[MCP_SERVERS] = JsonInstant.encodeToString(settings.mcpServers)
+            preferences[WEBDAV_CONFIG] = JsonInstant.encodeToString(settings.webDavConfig)
+            preferences[S3_CONFIG] = JsonInstant.encodeToString(settings.s3Config)
+            preferences[POSTGRES_GATEWAY_CONFIG] = JsonInstant.encodeToString(settings.postgresGatewayConfig)
+            preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(settings.ttsProviders)
+            if (settings.selectedTTSProviderId != null) {
+                preferences[SELECTED_TTS_PROVIDER] = settings.selectedTTSProviderId.toString()
+            } else {
+                preferences.remove(SELECTED_TTS_PROVIDER)
+            }
+            preferences[DEFAULT_TTS_PLAYBACK_SPEED] = settings.defaultTTSPlaybackSpeed.coerceIn(0.5f, 2.0f)
+            preferences[NETWORK_SETTING] = JsonInstant.encodeToString(settings.networkSetting)
+            preferences[MODE_INJECTIONS] = JsonInstant.encodeToString(settings.modeInjections)
+            preferences[LOREBOOKS] = JsonInstant.encodeToString(settings.lorebooks)
+            preferences[QUICK_MESSAGES] = JsonInstant.encodeToString(settings.quickMessages)
+            preferences[WEB_SERVER_ENABLED] = settings.webServerEnabled
+            preferences[WEB_SERVER_PORT] = settings.webServerPort
+            preferences[WEB_SERVER_JWT_ENABLED] = settings.webServerJwtEnabled
+            preferences[WEB_SERVER_ACCESS_PASSWORD] = settings.webServerAccessPassword
+            preferences[WEB_SERVER_LOCALHOST_ONLY] = settings.webServerLocalhostOnly
+            preferences[BACKUP_REMINDER_CONFIG] = JsonInstant.encodeToString(settings.backupReminderConfig)
+            preferences[LAUNCH_COUNT] = settings.launchCount
+            preferences[SPONSOR_ALERT_DISMISSED_AT] = settings.sponsorAlertDismissedAt
+        }
+        }
+
     }
 
     private val dataStore = context.settingsStore
@@ -374,66 +446,7 @@ class SettingsStore(
             return
         }
         settingsFlow.value = settings
-        dataStore.edit { preferences ->
-            preferences[DYNAMIC_COLOR] = settings.dynamicColor
-            preferences[THEME_ID] = settings.themeId
-            preferences[CUSTOM_THEMES] = JsonInstant.encodeToString(settings.customThemes)
-            preferences[DEVELOPER_MODE] = settings.developerMode
-            preferences[DISPLAY_SETTING] = JsonInstant.encodeToString(settings.displaySetting)
-
-            preferences[ENABLE_WEB_SEARCH] = settings.enableWebSearch
-            preferences[ENABLE_SUBAGENT] = settings.enableSubagent
-            preferences[FAVORITE_MODELS] = JsonInstant.encodeToString(settings.favoriteModels)
-            preferences[SELECT_MODEL] = settings.chatModelId.toString()
-            preferences[TITLE_MODEL] = settings.titleModelId.toString()
-            preferences[TRANSLATE_MODEL] = settings.translateModeId.toString()
-            preferences[SUGGESTION_MODEL] = settings.suggestionModelId.toString()
-            preferences[IMAGE_GENERATION_MODEL] = settings.imageGenerationModelId.toString()
-            preferences[VIDEO_GENERATION_MODEL] = settings.videoGenerationModelId.toString()
-
-            preferences[TITLE_PROMPT] = settings.titlePrompt
-            preferences[TRANSLATION_PROMPT] = settings.translatePrompt
-            preferences[TRANSLATE_THINKING_BUDGET] = settings.translateThinkingBudget
-            preferences[SUGGESTION_PROMPT] = settings.suggestionPrompt
-            preferences[OCR_MODEL] = settings.ocrModelId.toString()
-            preferences[OCR_PROMPT] = settings.ocrPrompt
-            preferences[COMPRESS_MODEL] = settings.compressModelId.toString()
-            preferences[COMPRESS_PROMPT] = settings.compressPrompt
-
-            preferences[PROVIDERS] = JsonInstant.encodeToString(settings.providers)
-
-            preferences[ASSISTANTS] = JsonInstant.encodeToString(settings.assistants)
-            preferences[SELECT_ASSISTANT] = settings.assistantId.toString()
-            preferences[ASSISTANT_TAGS] = JsonInstant.encodeToString(settings.assistantTags)
-
-            preferences[SEARCH_SERVICES] = JsonInstant.encodeToString(settings.searchServices)
-            preferences[SEARCH_COMMON] = JsonInstant.encodeToString(settings.searchCommonOptions)
-            preferences[SEARCH_SELECTED] = settings.searchServiceSelected.coerceIn(0, settings.searchServices.size - 1)
-
-            preferences[MCP_SERVERS] = JsonInstant.encodeToString(settings.mcpServers)
-            preferences[WEBDAV_CONFIG] = JsonInstant.encodeToString(settings.webDavConfig)
-            preferences[S3_CONFIG] = JsonInstant.encodeToString(settings.s3Config)
-            preferences[POSTGRES_GATEWAY_CONFIG] = JsonInstant.encodeToString(settings.postgresGatewayConfig)
-            preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(settings.ttsProviders)
-            if (settings.selectedTTSProviderId != null) {
-                preferences[SELECTED_TTS_PROVIDER] = settings.selectedTTSProviderId.toString()
-            } else {
-                preferences.remove(SELECTED_TTS_PROVIDER)
-            }
-            preferences[DEFAULT_TTS_PLAYBACK_SPEED] = settings.defaultTTSPlaybackSpeed.coerceIn(0.5f, 2.0f)
-            preferences[NETWORK_SETTING] = JsonInstant.encodeToString(settings.networkSetting)
-            preferences[MODE_INJECTIONS] = JsonInstant.encodeToString(settings.modeInjections)
-            preferences[LOREBOOKS] = JsonInstant.encodeToString(settings.lorebooks)
-            preferences[QUICK_MESSAGES] = JsonInstant.encodeToString(settings.quickMessages)
-            preferences[WEB_SERVER_ENABLED] = settings.webServerEnabled
-            preferences[WEB_SERVER_PORT] = settings.webServerPort
-            preferences[WEB_SERVER_JWT_ENABLED] = settings.webServerJwtEnabled
-            preferences[WEB_SERVER_ACCESS_PASSWORD] = settings.webServerAccessPassword
-            preferences[WEB_SERVER_LOCALHOST_ONLY] = settings.webServerLocalhostOnly
-            preferences[BACKUP_REMINDER_CONFIG] = JsonInstant.encodeToString(settings.backupReminderConfig)
-            preferences[LAUNCH_COUNT] = settings.launchCount
-            preferences[SPONSOR_ALERT_DISMISSED_AT] = settings.sponsorAlertDismissedAt
-        }
+        persistSettings(dataStore, settings)
     }
 
     suspend fun update(fn: (Settings) -> Settings) {

--- a/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/datastore/PreferencesStore.kt
@@ -586,6 +586,15 @@ data class Settings(
 }
 
 @Serializable
+data class NetworkSetting(
+    val userAgent: String = "",
+    val proxyUrl: String = "",
+    val proxyUsername: String = "",
+    val proxyPassword: String = "",
+    val enableAutoRetry: Boolean = true,
+)
+
+@Serializable
 enum class ChatFontFamily {
     @SerialName("default")
     DEFAULT,
@@ -780,10 +789,4 @@ val DEFAULT_MODE_INJECTIONS = listOf(
     )
 )
 
-@Serializable
-data class NetworkSetting(
-    val userAgent: String = "",
-    val proxyUrl: String = "",
-    val proxyUsername: String = "",
-    val proxyPassword: String = "",
-)
+

--- a/app/src/main/java/com/eterultimate/eteruee/data/db/AppDatabaseFactory.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/db/AppDatabaseFactory.kt
@@ -1,0 +1,34 @@
+package com.eterultimate.eteruee.data.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.eterultimate.eteruee.data.db.fts.MessageFtsSchema
+import com.eterultimate.eteruee.data.db.migrations.Migration_11_12
+import com.eterultimate.eteruee.data.db.migrations.Migration_13_14
+import com.eterultimate.eteruee.data.db.migrations.Migration_14_15
+import com.eterultimate.eteruee.data.db.migrations.Migration_15_16
+import com.eterultimate.eteruee.data.db.migrations.Migration_6_7
+import com.eterultimate.eteruee.data.db.migrations.MIGRATION_17_18
+
+/** Shared schema, migrations and driver for the app and staged backup validation. */
+internal object AppDatabaseFactory {
+    fun create(context: Context, name: String = SQLiteConfiguration.DATABASE_NAME): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, name)
+            .setDriver(BundledSQLiteDriver())
+            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+            .addMigrations(Migration_6_7, Migration_11_12, Migration_13_14, Migration_14_15, Migration_15_16, MIGRATION_17_18)
+            .addCallback(object : RoomDatabase.Callback() {
+                override fun onOpen(db: SupportSQLiteDatabase) {
+                    MessageFtsSchema.ensure(db)
+                }
+
+                override fun onOpen(connection: SQLiteConnection) {
+                    MessageFtsSchema.ensure(connection)
+                }
+            })
+            .build()
+}

--- a/app/src/main/java/com/eterultimate/eteruee/data/db/SQLiteConfiguration.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/db/SQLiteConfiguration.kt
@@ -1,0 +1,6 @@
+package com.eterultimate.eteruee.data.db
+
+/** Shared database name for the live database and staged backup validation. */
+internal object SQLiteConfiguration {
+    const val DATABASE_NAME = "rikka_hub"
+}

--- a/app/src/main/java/com/eterultimate/eteruee/data/db/fts/MessageFtsManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/db/fts/MessageFtsManager.kt
@@ -67,13 +67,24 @@ class MessageFtsManager(private val database: AppDatabase) {
         }
     }
 
-    suspend fun search(keyword: String): List<MessageSearchResult> = withContext(Dispatchers.IO) {
+    suspend fun search(keyword: String, assistantId: String? = null): List<MessageSearchResult> = withContext(Dispatchers.IO) {
         val ftsQuery = keyword.toFtsQuery()
         if (ftsQuery.isBlank()) {
             return@withContext emptyList()
         }
 
         val results = mutableListOf<MessageSearchResult>()
+        val assistantFilter = if (assistantId != null) {
+            """
+            AND EXISTS (
+                SELECT 1 FROM ConversationEntity AS conversation
+                WHERE conversation.id = message_fts.conversation_id
+                  AND conversation.assistant_id = ?
+            )
+            """.trimIndent()
+        } else {
+            ""
+        }
         database.useWriterConnection { connection ->
             MessageFtsSchema.ensure(connection)
             runCatching {
@@ -83,10 +94,11 @@ class MessageFtsManager(private val database: AppDatabase) {
                            snippet(message_fts, 0, '[', ']', '...', 30) AS snippet
                     FROM message_fts
                     WHERE text MATCH ?
+                    $assistantFilter
                     ORDER BY rank, update_at DESC
                     LIMIT 50
                     """.trimIndent(),
-                    arrayOf(ftsQuery)
+                    if (assistantId != null) arrayOf(ftsQuery, assistantId) else arrayOf(ftsQuery)
                 ) { statement ->
                     while (statement.step()) {
                         results.add(statement.toSearchResult())
@@ -98,7 +110,7 @@ class MessageFtsManager(private val database: AppDatabase) {
             }
 
             if (results.isEmpty()) {
-                results.addAll(searchByLike(connection, keyword))
+                results.addAll(searchByLike(connection, keyword, assistantId))
             }
         }
 
@@ -106,18 +118,34 @@ class MessageFtsManager(private val database: AppDatabase) {
         results
     }
 
-    private suspend fun searchByLike(connection: PooledConnection, keyword: String): List<MessageSearchResult> {
+    private suspend fun searchByLike(
+        connection: PooledConnection,
+        keyword: String,
+        assistantId: String? = null,
+    ): List<MessageSearchResult> {
         val results = mutableListOf<MessageSearchResult>()
+        val assistantFilter = if (assistantId != null) {
+            """
+            AND EXISTS (
+                SELECT 1 FROM ConversationEntity AS conversation
+                WHERE conversation.id = message_fts.conversation_id
+                  AND conversation.assistant_id = ?
+            )
+            """.trimIndent()
+        } else {
+            ""
+        }
         connection.query(
             """
             SELECT node_id, message_id, conversation_id, title, update_at,
                    substr(text, 1, 200) AS snippet
             FROM message_fts
             WHERE text LIKE ? ESCAPE '\'
+            $assistantFilter
             ORDER BY update_at DESC
             LIMIT 50
             """.trimIndent(),
-            arrayOf("%${keyword.escapeLike()}%")
+            if (assistantId != null) arrayOf("%${keyword.escapeLike()}%", assistantId) else arrayOf("%${keyword.escapeLike()}%")
         ) { statement ->
             while (statement.step()) {
                 results.add(statement.toSearchResult())

--- a/app/src/main/java/com/eterultimate/eteruee/data/files/FilesManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/files/FilesManager.kt
@@ -412,6 +412,30 @@ class FilesManager(
         false
     }
 
+    suspend fun deleteOlderThan(
+        folder: String = FileFolders.UPLOAD,
+        cutoffMillis: Long,
+    ): Boolean = withContext(Dispatchers.IO) {
+        var allDeleted = true
+        repository.listByFolder(folder).first()
+            .filter { it.createdAt < cutoffMillis }
+            .forEach { entity ->
+                val file = getFile(entity)
+                val deletedFromDisk = !file.exists() || runCatching {
+                    file.deleteRecursively()
+                }.getOrDefault(false)
+
+                if (deletedFromDisk) {
+                    if (repository.deleteById(entity.id) == 0) {
+                        allDeleted = false
+                    }
+                } else {
+                    allDeleted = false
+                }
+            }
+        allDeleted
+    }
+
     private fun createTargetFile(folder: String, displayName: String, mimeType: String?): File {
         val dir = File(context.filesDir, folder)
         if (!dir.exists()) {

--- a/app/src/main/java/com/eterultimate/eteruee/data/repository/ConversationRepository.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/repository/ConversationRepository.kt
@@ -272,7 +272,8 @@ class ConversationRepository(
         filesManager.deleteChatFiles(fullConversation.files)
     }
 
-    suspend fun searchMessages(keyword: String) = messageFtsManager.search(keyword)
+    suspend fun searchMessages(keyword: String, assistantId: Uuid? = null) =
+        messageFtsManager.search(keyword, assistantId?.toString())
 
     suspend fun rebuildAllIndexes(onProgress: (current: Int, total: Int) -> Unit = { _, _ -> }) {
         messageFtsManager.deleteAll()

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/BackupManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/BackupManager.kt
@@ -87,13 +87,22 @@ class BackupManager(
                         for (entry in zip.entries()) {
                             currentCoroutineContext().ensureActive()
                             if (entry.isDirectory) continue
+                            // Defense in depth: drop traversal segments before any path use
+                            // (resolveInside rejects them too, this keeps the check local).
+                            if (entry.name.split('/').any { it == ".." || it == "." }) continue
                             val target = when (entry.name) {
                                 "settings.json" -> File(staging, "settings.json")
                                 DatabaseBackup.ARCHIVE_DATABASE -> if (includeDatabase) stagedDatabase else null
                                 DatabaseBackup.WAL -> if (includeDatabase) stagedWal else null
                                 DatabaseBackup.SHM -> null // Rebuilt by SQLite; never restore shared-memory state.
                                 else -> if (includeFiles && isAttachment(entry.name)) {
-                                    PendingRestore.resolveInside(File(payload, "files"), entry.name)
+                                    val staged = PendingRestore.resolveInside(File(payload, "files"), entry.name)
+                                    // Canonical containment re-check at the sink: the staged
+                                    // target must stay inside the staging files directory.
+                                    check(staged.canonicalPath.startsWith(File(payload, "files").canonicalPath + File.separator)) {
+                                        "Backup entry escapes the staging directory"
+                                    }
+                                    staged
                                 } else null
                             } ?: continue
                             require(seen.add(entry.name)) { "Duplicate backup entry: ${entry.name}" }

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/BackupManager.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/BackupManager.kt
@@ -1,0 +1,170 @@
+package com.eterultimate.eteruee.data.sync
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import com.eterultimate.eteruee.data.datastore.Settings
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.datastore.migration.SettingsJsonMigrator
+import com.eterultimate.eteruee.data.db.AppDatabaseFactory
+import com.eterultimate.eteruee.data.db.AppDatabase
+import com.eterultimate.eteruee.data.db.SQLiteConfiguration
+import com.eterultimate.eteruee.data.files.FileFolders
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+/** Shared archive format and restore lifecycle for local, WebDAV and S3 backups. */
+class BackupManager(
+    private val context: Context,
+    private val database: AppDatabase,
+    private val settingsStore: SettingsStore,
+    private val json: Json,
+) {
+    private val restoreMutex = Mutex()
+
+    suspend fun createBackup(includeDatabase: Boolean, includeFiles: Boolean): File = withContext(Dispatchers.IO) {
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))
+        val archive = File.createTempFile("backup_${timestamp}_", ".zip", context.cacheDir)
+        val staging = Files.createTempDirectory(context.cacheDir.toPath(), "backup-").toFile()
+        try {
+            val settings = settingsStore.settingsFlowRaw.first()
+            ZipOutputStream(FileOutputStream(archive)).use { zip ->
+                zip.putNextEntry(ZipEntry("settings.json"))
+                zip.write(json.encodeToString(settings).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+                if (includeDatabase) {
+                    val snapshot = File(staging, SQLiteConfiguration.DATABASE_NAME)
+                    DatabaseBackup.createSnapshot(database.openHelper.writableDatabase, snapshot)
+                    addFile(zip, snapshot, DatabaseBackup.ARCHIVE_DATABASE)
+                }
+                if (includeFiles) {
+                    for (folder in listOf(FileFolders.UPLOAD, FileFolders.SKILLS)) {
+                        val directory = File(context.filesDir, folder)
+                        val files = if (folder == FileFolders.SKILLS) directory.walkTopDown().asSequence()
+                        else directory.listFiles().orEmpty().asSequence()
+                        for (file in files.filter { it.isFile }) {
+                            currentCoroutineContext().ensureActive()
+                            val relative = file.relativeTo(directory).invariantSeparatorsPath
+                            PendingRestore.resolveInside(directory, relative)
+                            addFile(zip, file, "$folder/$relative")
+                        }
+                    }
+                }
+            }
+            archive
+        } catch (e: Throwable) {
+            archive.delete()
+            throw e
+        } finally {
+            staging.deleteRecursively()
+        }
+    }
+
+    suspend fun stageRestore(archive: File, includeDatabase: Boolean, includeFiles: Boolean) =
+        withContext(Dispatchers.IO) {
+            restoreMutex.withLock {
+                val restore = pendingRestore(context)
+                val staging = restore.createStagingDirectory()
+                try {
+                    val payload = File(staging, "payload")
+                    val stagedDatabase = File(payload, "database/${SQLiteConfiguration.DATABASE_NAME}")
+                    val stagedWal = File(stagedDatabase.path + "-wal")
+                    val seen = mutableSetOf<String>()
+                    var restoredEntries = 0
+                    ZipFile(archive).use { zip ->
+                        for (entry in zip.entries()) {
+                            currentCoroutineContext().ensureActive()
+                            if (entry.isDirectory) continue
+                            val target = when (entry.name) {
+                                "settings.json" -> File(staging, "settings.json")
+                                DatabaseBackup.ARCHIVE_DATABASE -> if (includeDatabase) stagedDatabase else null
+                                DatabaseBackup.WAL -> if (includeDatabase) stagedWal else null
+                                DatabaseBackup.SHM -> null // Rebuilt by SQLite; never restore shared-memory state.
+                                else -> if (includeFiles && isAttachment(entry.name)) {
+                                    PendingRestore.resolveInside(File(payload, "files"), entry.name)
+                                } else null
+                            } ?: continue
+                            require(seen.add(entry.name)) { "Duplicate backup entry: ${entry.name}" }
+                            check(target.parentFile!!.isDirectory || target.parentFile!!.mkdirs()) {
+                                "Cannot create backup staging directory"
+                            }
+                            zip.getInputStream(entry).use { input ->
+                                FileOutputStream(target).use { output ->
+                                    input.copyTo(output)
+                                    output.fd.sync()
+                                }
+                            }
+                            restoredEntries++
+                        }
+                    }
+                    require(restoredEntries > 0) { "No selected data found in the backup" }
+                    require(!stagedWal.exists() || stagedDatabase.exists()) { "Backup WAL has no matching database" }
+                    if (stagedDatabase.exists()) {
+                        DatabaseBackup.normalize(context, stagedDatabase)
+                        // Reject unsupported schemas before publishing; run supported old migrations on the copy.
+                        val room = AppDatabaseFactory.create(context, stagedDatabase.absolutePath)
+                        try {
+                            DatabaseBackup.checkpoint(room.openHelper.writableDatabase)
+                        } finally {
+                            room.close()
+                        }
+                        DatabaseBackup.removeSidecars(stagedDatabase)
+                    }
+
+                    val settingsFile = File(staging, "settings.json")
+                    if (settingsFile.exists()) {
+                        val settings = json.decodeFromString<Settings>(SettingsJsonMigrator.migrate(settingsFile.readText()))
+                        require(!settings.init) { "Backup contains uninitialized settings" }
+                        // Persist the migrated value once, including generated IDs, for restart/retry consistency.
+                        PendingRestore.writeDurably(settingsFile, json.encodeToString(settings))
+                    }
+                    currentCoroutineContext().ensureActive()
+                    restore.publish(staging)
+                } finally {
+                    staging.deleteRecursively()
+                }
+            }
+        }
+
+    private fun isAttachment(name: String): Boolean {
+        val folder = name.substringBefore('/')
+        if (folder !in listOf(FileFolders.UPLOAD, FileFolders.SKILLS) || '/' !in name) return false
+        val relative = name.substringAfter('/')
+        require(relative.isNotBlank()) { "Invalid backup attachment: $name" }
+        require(folder == FileFolders.SKILLS || '/' !in relative) { "Invalid backup attachment: $name" }
+        return true
+    }
+
+    private fun addFile(zip: ZipOutputStream, file: File, name: String) {
+        zip.putNextEntry(ZipEntry(name))
+        file.inputStream().use { it.copyTo(zip) }
+        zip.closeEntry()
+    }
+
+    companion object {
+        private fun pendingRestore(context: Context) = PendingRestore(
+            root = File(context.noBackupFilesDir, "backup-restore"),
+            databaseFile = context.getDatabasePath(SQLiteConfiguration.DATABASE_NAME),
+            filesDir = context.filesDir,
+        )
+
+        /** Must finish before Koin, Room, SettingsStore or any background consumers are initialized. */
+        suspend fun applyPendingRestore(context: Context, json: Json): Boolean = withContext(Dispatchers.IO) {
+            pendingRestore(context).apply { settingsJson ->
+                SettingsStore.restoreBeforeInitialization(context, json.decodeFromString<Settings>(settingsJson))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/DatabaseBackup.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/DatabaseBackup.kt
@@ -1,0 +1,64 @@
+package com.eterultimate.eteruee.data.sync
+
+import android.content.Context
+import android.database.DatabaseErrorHandler
+import android.database.sqlite.SQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.eterultimate.eteruee.data.db.SQLiteConfiguration
+import java.io.File
+
+internal object DatabaseBackup {
+    const val ARCHIVE_DATABASE = "rikka_hub.db"
+    const val WAL = "rikka_hub-wal"
+    const val SHM = "rikka_hub-shm"
+
+    /** VACUUM INTO includes committed WAL contents in a consistent, standalone snapshot. */
+    fun createSnapshot(database: SupportSQLiteDatabase, destination: File) {
+        check(!destination.exists()) { "Backup snapshot already exists" }
+        database.execSQL("VACUUM main INTO ?", arrayOf(destination.absolutePath))
+    }
+
+    /** Only opens the staged copy. The caller must place its matching WAL beside it first. */
+    fun normalize(context: Context, databaseFile: File) {
+        require(databaseFile.isFile && databaseFile.length() > 0) { "Backup database is missing or empty" }
+        SQLiteDatabase.openDatabase(
+            databaseFile.absolutePath,
+            null,
+            SQLiteDatabase.OPEN_READWRITE,
+            DatabaseErrorHandler { _ -> error("Backup database is corrupt") },
+        ).use { database ->
+            checkpoint(database.rawQuery("PRAGMA wal_checkpoint(TRUNCATE)", null))
+            database.rawQuery("PRAGMA integrity_check", null).use { cursor ->
+                check(cursor.moveToFirst() && cursor.getString(0) == "ok" && !cursor.moveToNext()) {
+                    "Backup database failed its integrity check"
+                }
+            }
+        }
+        removeSidecars(databaseFile)
+    }
+
+    fun checkpoint(cursor: android.database.Cursor) {
+        cursor.use {
+            check(it.moveToFirst() && it.getInt(0) == 0) {
+                "Could not checkpoint the backup database"
+            }
+        }
+    }
+
+    fun checkpoint(database: SupportSQLiteDatabase) {
+        database.query("PRAGMA wal_checkpoint(TRUNCATE)").use { cursor ->
+            check(cursor.moveToFirst() && cursor.getInt(0) == 0) {
+                "Could not checkpoint the backup database"
+            }
+        }
+    }
+
+    fun removeSidecars(databaseFile: File) {
+        // All connections must be closed and committed WAL data checkpointed before removal.
+        check(File(databaseFile.path + "-wal").length() == 0L) { "Backup WAL was not fully checkpointed" }
+        for (suffix in listOf("-wal", "-shm")) {
+            val sidecar = File(databaseFile.path + suffix)
+            check(!sidecar.exists() || sidecar.delete()) { "Could not remove staged database sidecar" }
+        }
+    }
+}

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/PendingRestore.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/PendingRestore.kt
@@ -1,0 +1,168 @@
+package com.eterultimate.eteruee.data.sync
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.util.UUID
+
+/**
+ * Staged restores live outside cache and are installed before any database/settings consumers start.
+ * The journal and atomic moves allow an interrupted installation to resume on the next launch.
+ */
+internal class PendingRestore(
+    private val root: File,
+    private val databaseFile: File,
+    private val filesDir: File,
+) {
+    private val pending get() = File(root, "pending")
+
+    fun createStagingDirectory(): File {
+        check(!pending.exists()) { "A backup restore is already pending. Restart the app first." }
+        check(root.isDirectory || root.mkdirs()) { "Cannot create backup staging directory" }
+        return Files.createTempDirectory(root.toPath(), "preparing-").toFile()
+    }
+
+    fun publish(staging: File) {
+        check(!pending.exists()) { "A backup restore is already pending. Restart the app first." }
+        move(staging, pending)
+    }
+
+    suspend fun apply(restoreSettings: suspend (String) -> Unit): Boolean {
+        // Completed restores must never be replayed, even if cleanup was interrupted.
+        root.listFiles()?.filter {
+            it.name.startsWith("completed-") || it.name.startsWith("preparing-")
+        }?.forEach { it.deleteRecursively() }
+        if (!pending.isDirectory) return false
+
+        val journal = File(pending, "journal.json")
+        val entries = if (journal.exists()) {
+            // An existing journal may describe an interrupted installation; keep it if reading fails.
+            Json.decodeFromString<List<RestoreEntry>>(journal.readText())
+        } else {
+            try {
+                buildEntries().also { writeDurably(journal, Json.encodeToString(it)) }
+            } catch (e: Exception) {
+                // No live files have been changed yet, so this restore can be safely rejected.
+                move(pending, File(root, "failed-${UUID.randomUUID()}"))
+                throw RestoreFailedException(e)
+            }
+        }
+        try {
+            entries.forEach { entry ->
+                val target = targetFile(entry.path)
+                val original = File(pending, "originals/${entry.path}")
+                val source = File(pending, "payload/${entry.path}")
+                if (entry.install && !source.exists()) {
+                    // A previous process already moved this source into place.
+                    check(target.isFile) { "Interrupted restore is missing ${entry.path}" }
+                } else {
+                    if (entry.hadOriginal && !original.exists()) move(target, original)
+                    if (entry.install) move(source, target)
+                }
+            }
+            val settings = File(pending, "settings.json")
+            if (settings.isFile) restoreSettings(settings.readText())
+        } catch (e: Exception) {
+            try {
+                rollback(entries)
+            } catch (rollbackError: Exception) {
+                e.addSuppressed(rollbackError)
+                // Do not start the app with a partially restored database. Keep the journal for retry.
+                throw e
+            }
+            move(pending, File(root, "failed-${UUID.randomUUID()}"))
+            throw RestoreFailedException(e)
+        }
+
+        // Commit by removing the pending name atomically before any live connection can be opened.
+        // If this move fails, startup aborts and the next launch retries the same installation.
+        val completed = File(root, "completed-${UUID.randomUUID()}")
+        move(pending, completed)
+        completed.deleteRecursively()
+        return true
+    }
+
+    private fun buildEntries(): List<RestoreEntry> {
+        val payload = File(pending, "payload")
+        val paths = payload.walkTopDown().filter { it.isFile }.map {
+            it.relativeTo(payload).invariantSeparatorsPath
+        }.toList().sorted()
+        val entries = paths.map { path ->
+            RestoreEntry(path, install = true, hadOriginal = targetFile(path).exists())
+        }.toMutableList()
+        if (paths.contains("database/${databaseFile.name}")) {
+            // The new database is standalone. Keep the old DB's sidecars with the old DB only.
+            for (suffix in listOf("-wal", "-shm", "-journal")) {
+                val path = "database/${databaseFile.name}$suffix"
+                entries.add(0, RestoreEntry(path, install = false, hadOriginal = targetFile(path).exists()))
+            }
+        }
+        return entries
+    }
+
+    private fun rollback(entries: List<RestoreEntry>) {
+        entries.asReversed().forEach { entry ->
+            val target = targetFile(entry.path)
+            val original = File(pending, "originals/${entry.path}")
+            val source = File(pending, "payload/${entry.path}")
+            if (entry.install && !source.exists() && target.exists()) move(target, source)
+            if (original.exists()) move(original, target)
+        }
+    }
+
+    private fun targetFile(path: String): File {
+        return when {
+            path.startsWith("database/") -> {
+                val name = path.removePrefix("database/")
+                require(name in listOf(
+                    databaseFile.name, databaseFile.name + "-wal",
+                    databaseFile.name + "-shm", databaseFile.name + "-journal"
+                )) {
+                    "Invalid restore database path"
+                }
+                File(databaseFile.parentFile, name)
+            }
+            path.startsWith("files/") -> resolveInside(filesDir, path.removePrefix("files/"))
+            else -> error("Invalid restore path: $path")
+        }
+    }
+
+    @Serializable
+    private data class RestoreEntry(val path: String, val install: Boolean, val hadOriginal: Boolean)
+
+    companion object {
+        fun resolveInside(root: File, relativePath: String): File {
+            require(relativePath.isNotBlank() && !relativePath.startsWith('/') &&
+                '\\' !in relativePath && relativePath.split('/').none { it == ".." || it == "." }) {
+                "Invalid backup file path: $relativePath"
+            }
+            val target = File(root, relativePath).canonicalFile
+            require(target.path.startsWith(root.canonicalPath + File.separator)) {
+                "Backup file is outside its target directory"
+            }
+            return target
+        }
+
+        fun writeDurably(file: File, text: String) {
+            val temporary = File(file.parentFile, file.name + ".tmp")
+            FileOutputStream(temporary).use { output ->
+                output.write(text.toByteArray(Charsets.UTF_8))
+                output.fd.sync()
+            }
+            move(temporary, file)
+        }
+
+        private fun move(source: File, target: File) {
+            val parent = requireNotNull(target.parentFile)
+            check(parent.isDirectory || parent.mkdirs()) { "Cannot create restore directory" }
+            Files.move(source.toPath(), target.toPath(), ATOMIC_MOVE, REPLACE_EXISTING)
+        }
+    }
+}
+
+/** Only thrown when original files are intact and the failed import has been isolated. */
+internal class RestoreFailedException(cause: Exception) : Exception("Backup restore failed; original files restored", cause)

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/S3Sync.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/S3Sync.kt
@@ -1,34 +1,20 @@
-﻿package com.eterultimate.eteruee.data.sync
+package com.eterultimate.eteruee.data.sync
 
 import android.content.Context
 import android.util.Log
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
-import com.eterultimate.eteruee.data.files.FileFolders
-import com.eterultimate.eteruee.data.files.SkillPaths
-import com.eterultimate.eteruee.data.datastore.Settings
-import com.eterultimate.eteruee.data.datastore.SettingsStore
-import com.eterultimate.eteruee.data.datastore.migration.SettingsJsonMigrator
 import com.eterultimate.eteruee.data.sync.s3.S3Client
 import com.eterultimate.eteruee.data.sync.s3.S3Config
 import com.eterultimate.eteruee.utils.fileSizeToString
 import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
-import java.util.zip.ZipOutputStream
 
 private const val TAG = "S3Sync"
 
 class S3Sync(
-    private val settingsStore: SettingsStore,
-    private val json: Json,
+    private val backupManager: BackupManager,
     private val context: Context,
     private val httpClient: HttpClient,
 ) {
@@ -82,7 +68,7 @@ class S3Sync(
 
     suspend fun restoreFromS3(config: S3Config, item: S3BackupItem) = withContext(Dispatchers.IO) {
         val client = getS3Client(config)
-        val backupFile = File(context.cacheDir, item.displayName)
+        val backupFile = File.createTempFile("restore-", ".zip", context.cacheDir)
 
         try {
             // Download backup file directly to file to avoid OOM
@@ -108,251 +94,17 @@ class S3Sync(
         Log.i(TAG, "deleteS3BackupFile: Deleted ${item.key}")
     }
 
-    suspend fun prepareBackupFile(config: S3Config): File = withContext(Dispatchers.IO) {
-        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))
-        val backupFile = File(context.cacheDir, "backup_$timestamp.zip")
+    suspend fun prepareBackupFile(config: S3Config): File = backupManager.createBackup(
+        includeDatabase = S3Config.BackupItem.DATABASE in config.items,
+        includeFiles = S3Config.BackupItem.FILES in config.items,
+    )
 
-        if (backupFile.exists()) {
-            backupFile.delete()
-        }
+    private suspend fun restoreFromBackupFile(backupFile: File, config: S3Config) = backupManager.stageRestore(
+        archive = backupFile,
+        includeDatabase = S3Config.BackupItem.DATABASE in config.items,
+        includeFiles = S3Config.BackupItem.FILES in config.items,
+    )
 
-        // Create zip file and backup data
-        ZipOutputStream(FileOutputStream(backupFile)).use { zipOut ->
-            addVirtualFileToZip(
-                zipOut = zipOut,
-                name = "settings.json",
-                content = json.encodeToString(settingsStore.settingsFlow.value)
-            )
-
-            // Backup database files
-            if (config.items.contains(S3Config.BackupItem.DATABASE)) {
-                val dbFile = context.getDatabasePath("rikka_hub")
-                if (dbFile.exists()) {
-                    addFileToZip(zipOut, dbFile, "rikka_hub.db")
-                }
-
-                val walFile = File(dbFile.parentFile, "rikka_hub-wal")
-                if (walFile.exists()) {
-                    addFileToZip(zipOut, walFile, "rikka_hub-wal")
-                }
-
-                val shmFile = File(dbFile.parentFile, "rikka_hub-shm")
-                if (shmFile.exists()) {
-                    addFileToZip(zipOut, shmFile, "rikka_hub-shm")
-                }
-            }
-
-            // Backup app files
-            if (config.items.contains(S3Config.BackupItem.FILES)) {
-                val uploadFolder = File(context.filesDir, FileFolders.UPLOAD)
-                if (uploadFolder.exists() && uploadFolder.isDirectory) {
-                    Log.i(TAG, "prepareBackupFile: Backing up files from ${uploadFolder.absolutePath}")
-                    uploadFolder.listFiles()?.forEach { file ->
-                        if (file.isFile) {
-                            addFileToZip(zipOut, file, "${FileFolders.UPLOAD}/${file.name}")
-                        }
-                    }
-                } else {
-                    Log.w(TAG, "prepareBackupFile: Upload folder does not exist or is not a directory")
-                }
-
-                val skillsFolder = File(context.filesDir, FileFolders.SKILLS)
-                if (skillsFolder.exists() && skillsFolder.isDirectory) {
-                    Log.i(TAG, "prepareBackupFile: Backing up skills from ${skillsFolder.absolutePath}")
-                    addDirectoryToZip(
-                        zipOut = zipOut,
-                        rootDir = skillsFolder,
-                        currentDir = skillsFolder,
-                        entryPrefix = "${FileFolders.SKILLS}/"
-                    )
-                } else {
-                    Log.w(TAG, "prepareBackupFile: Skills folder does not exist or is not a directory")
-                }
-            }
-        }
-
-        Log.i(
-            TAG,
-            "prepareBackupFile: Created backup file ${backupFile.name} (${backupFile.length().fileSizeToString()})"
-        )
-        backupFile
-    }
-
-    private suspend fun restoreFromBackupFile(backupFile: File, config: S3Config) = withContext(Dispatchers.IO) {
-        Log.i(TAG, "restoreFromBackupFile: Starting restore from ${backupFile.absolutePath}")
-
-        ZipInputStream(FileInputStream(backupFile)).use { zipIn ->
-            var entry: ZipEntry?
-            while (zipIn.nextEntry.also { entry = it } != null) {
-                entry?.let { zipEntry ->
-                    Log.i(TAG, "restoreFromBackupFile: Processing entry ${zipEntry.name}")
-
-                    when (zipEntry.name) {
-                        "settings.json" -> {
-                            val settingsJson = zipIn.readBytes().toString(Charsets.UTF_8)
-                            Log.i(TAG, "restoreFromBackupFile: Restoring settings")
-                            try {
-                                val migratedJson = SettingsJsonMigrator.migrate(settingsJson)
-                                val settings = json.decodeFromString<Settings>(migratedJson)
-                                settingsStore.update(settings)
-                                Log.i(TAG, "restoreFromBackupFile: Settings restored successfully")
-                            } catch (e: Exception) {
-                                Log.e(TAG, "restoreFromBackupFile: Failed to restore settings", e)
-                                throw Exception("Failed to restore settings: ${e.message}")
-                            }
-                        }
-
-                        "rikka_hub.db", "rikka_hub-wal", "rikka_hub-shm" -> {
-                            if (config.items.contains(S3Config.BackupItem.DATABASE)) {
-                                val dbFile = when (zipEntry.name) {
-                                    "rikka_hub.db" -> context.getDatabasePath("rikka_hub")
-                                    "rikka_hub-wal" -> File(
-                                        context.getDatabasePath("rikka_hub").parentFile,
-                                        "rikka_hub-wal"
-                                    )
-
-                                    "rikka_hub-shm" -> File(
-                                        context.getDatabasePath("rikka_hub").parentFile,
-                                        "rikka_hub-shm"
-                                    )
-
-                                    else -> null
-                                }
-
-                                dbFile?.let { targetFile ->
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restoring ${zipEntry.name} to ${targetFile.absolutePath}"
-                                    )
-                                    targetFile.parentFile?.mkdirs()
-                                    FileOutputStream(targetFile).use { outputStream ->
-                                        zipIn.copyTo(outputStream)
-                                    }
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restored ${zipEntry.name} (${targetFile.length()} bytes)"
-                                    )
-                                }
-                            }
-                        }
-
-                        else -> {
-                            if (config.items.contains(S3Config.BackupItem.FILES) &&
-                                zipEntry.name.startsWith("${FileFolders.UPLOAD}/")
-                            ) {
-                                val fileName = zipEntry.name.substringAfter("${FileFolders.UPLOAD}/")
-                                if (fileName.isNotEmpty()) {
-                                    val uploadFolder = File(context.filesDir, FileFolders.UPLOAD)
-                                    if (!uploadFolder.exists()) {
-                                        uploadFolder.mkdirs()
-                                        Log.i(TAG, "restoreFromBackupFile: Created upload directory")
-                                    }
-
-                                    val targetFile = File(uploadFolder, fileName)
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restoring file ${zipEntry.name} to ${targetFile.absolutePath}"
-                                    )
-
-                                    try {
-                                        FileOutputStream(targetFile).use { outputStream ->
-                                            zipIn.copyTo(outputStream)
-                                        }
-                                        Log.i(
-                                            TAG,
-                                            "restoreFromBackupFile: Restored ${zipEntry.name} (${targetFile.length()} bytes)"
-                                        )
-                                    } catch (e: Exception) {
-                                        Log.e(TAG, "restoreFromBackupFile: Failed to restore file ${zipEntry.name}", e)
-                                        throw Exception("Failed to restore file ${zipEntry.name}: ${e.message}")
-                                    }
-                                }
-                            } else if (config.items.contains(S3Config.BackupItem.FILES) &&
-                                zipEntry.name.startsWith("${FileFolders.SKILLS}/")
-                            ) {
-                                restoreSkillEntry(zipIn, zipEntry.name)
-                            } else {
-                                Log.i(TAG, "restoreFromBackupFile: Skipping entry ${zipEntry.name}")
-                            }
-                        }
-                    }
-
-                    zipIn.closeEntry()
-                }
-            }
-        }
-
-        Log.i(TAG, "restoreFromBackupFile: Restore completed successfully")
-    }
-
-    private fun addFileToZip(zipOut: ZipOutputStream, file: File, entryName: String) {
-        FileInputStream(file).use { fis ->
-            val zipEntry = ZipEntry(entryName)
-            zipOut.putNextEntry(zipEntry)
-            fis.copyTo(zipOut)
-            zipOut.closeEntry()
-            Log.d(TAG, "addFileToZip: Added $entryName (${file.length()} bytes) to zip")
-        }
-    }
-
-    private fun addDirectoryToZip(
-        zipOut: ZipOutputStream,
-        rootDir: File,
-        currentDir: File,
-        entryPrefix: String,
-    ) {
-        currentDir.listFiles()?.forEach { file ->
-            if (file.isDirectory) {
-                addDirectoryToZip(
-                    zipOut = zipOut,
-                    rootDir = rootDir,
-                    currentDir = file,
-                    entryPrefix = entryPrefix,
-                )
-            } else if (file.isFile) {
-                val relativePath = file.relativeTo(rootDir).invariantSeparatorsPath
-                addFileToZip(zipOut, file, "$entryPrefix$relativePath")
-            }
-        }
-    }
-
-    private fun restoreSkillEntry(zipIn: ZipInputStream, entryName: String) {
-        val relativePath = entryName.substringAfter("${FileFolders.SKILLS}/")
-        val skillName = relativePath.substringBefore('/', missingDelimiterValue = "")
-        val skillRelativePath = relativePath.substringAfter('/', missingDelimiterValue = "")
-
-        if (skillName.isBlank() || skillRelativePath.isBlank()) {
-            Log.w(TAG, "restoreFromBackupFile: Invalid skill entry $entryName")
-            return
-        }
-
-        val skillsRoot = File(context.filesDir, FileFolders.SKILLS).apply { mkdirs() }
-        val skillDir = SkillPaths.resolveSkillDir(skillsRoot, skillName)
-            ?: throw Exception("Invalid skill directory: $entryName")
-        val targetFile = SkillPaths.resolveSkillFile(skillDir, skillRelativePath)
-            ?: throw Exception("Invalid skill file path: $entryName")
-
-        skillDir.mkdirs()
-        targetFile.parentFile?.mkdirs()
-
-        try {
-            FileOutputStream(targetFile).use { outputStream ->
-                zipIn.copyTo(outputStream)
-            }
-            Log.i(TAG, "restoreFromBackupFile: Restored skill file $entryName (${targetFile.length()} bytes)")
-        } catch (e: Exception) {
-            Log.e(TAG, "restoreFromBackupFile: Failed to restore skill file $entryName", e)
-            throw Exception("Failed to restore skill file $entryName: ${e.message}")
-        }
-    }
-
-    private fun addVirtualFileToZip(zipOut: ZipOutputStream, name: String, content: String) {
-        val zipEntry = ZipEntry(name)
-        zipOut.putNextEntry(zipEntry)
-        zipOut.write(content.toByteArray())
-        zipOut.closeEntry()
-        Log.i(TAG, "addVirtualFileToZip: $name (${content.length} bytes)")
-    }
 }
 
 data class S3BackupItem(
@@ -361,4 +113,3 @@ data class S3BackupItem(
     val size: Long,
     val lastModified: Instant,
 )
-

--- a/app/src/main/java/com/eterultimate/eteruee/data/sync/webdav/WebDavSync.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/data/sync/webdav/WebDavSync.kt
@@ -1,33 +1,20 @@
-﻿package com.eterultimate.eteruee.data.sync.webdav
+package com.eterultimate.eteruee.data.sync.webdav
 
 import android.content.Context
 import android.util.Log
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
-import com.eterultimate.eteruee.data.files.FileFolders
-import com.eterultimate.eteruee.data.files.SkillPaths
-import com.eterultimate.eteruee.data.datastore.Settings
-import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.sync.BackupManager
 import com.eterultimate.eteruee.data.datastore.WebDavConfig
-import com.eterultimate.eteruee.data.datastore.migration.SettingsJsonMigrator
 import com.eterultimate.eteruee.utils.fileSizeToString
 import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
-import java.util.zip.ZipOutputStream
 
 private const val TAG = "WebDavSync"
 
 class WebDavSync(
-    private val settingsStore: SettingsStore,
-    private val json: Json,
+    private val backupManager: BackupManager,
     private val context: Context,
     private val httpClient: HttpClient,
 ) {
@@ -85,7 +72,7 @@ class WebDavSync(
 
     suspend fun restore(config: WebDavConfig, item: WebDavBackupItem) = withContext(Dispatchers.IO) {
         val client = getClient(config)
-        val backupFile = File(context.cacheDir, item.displayName)
+        val backupFile = File.createTempFile("restore-", ".zip", context.cacheDir)
 
         try {
             // Download backup file directly to file to avoid OOM
@@ -111,271 +98,21 @@ class WebDavSync(
         Log.i(TAG, "deleteBackupFile: Deleted ${item.displayName}")
     }
 
-    suspend fun restoreFromLocalFile(file: File, config: WebDavConfig) = withContext(Dispatchers.IO) {
-        Log.i(TAG, "restoreFromLocalFile: Starting restore from ${file.absolutePath}")
-
-        if (!file.exists()) {
-            throw Exception("Backup file does not exist")
-        }
-
-        if (!file.canRead()) {
-            throw Exception("Cannot read backup file")
-        }
-
-        try {
-            restoreFromBackupFile(file, config)
-            Log.i(TAG, "restoreFromLocalFile: Restore completed successfully")
-        } catch (e: Exception) {
-            Log.e(TAG, "restoreFromLocalFile: Failed to restore from local file", e)
-            throw Exception("Restore failed: ${e.message}")
-        }
+    suspend fun restoreFromLocalFile(file: File, config: WebDavConfig) {
+        restoreFromBackupFile(file, config)
     }
 
-    suspend fun prepareBackupFile(config: WebDavConfig): File = withContext(Dispatchers.IO) {
-        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))
-        val backupFile = File(context.cacheDir, "backup_$timestamp.zip")
+    suspend fun prepareBackupFile(config: WebDavConfig): File = backupManager.createBackup(
+        includeDatabase = WebDavConfig.BackupItem.DATABASE in config.items,
+        includeFiles = WebDavConfig.BackupItem.FILES in config.items,
+    )
 
-        if (backupFile.exists()) {
-            backupFile.delete()
-        }
+    private suspend fun restoreFromBackupFile(backupFile: File, config: WebDavConfig) = backupManager.stageRestore(
+        archive = backupFile,
+        includeDatabase = WebDavConfig.BackupItem.DATABASE in config.items,
+        includeFiles = WebDavConfig.BackupItem.FILES in config.items,
+    )
 
-        // Create zip file and backup data
-        ZipOutputStream(FileOutputStream(backupFile)).use { zipOut ->
-            addVirtualFileToZip(
-                zipOut = zipOut,
-                name = "settings.json",
-                content = json.encodeToString(settingsStore.settingsFlow.value)
-            )
-
-            // Backup database files
-            if (config.items.contains(WebDavConfig.BackupItem.DATABASE)) {
-                val dbFile = context.getDatabasePath("rikka_hub")
-                if (dbFile.exists()) {
-                    addFileToZip(zipOut, dbFile, "rikka_hub.db")
-                }
-
-                val walFile = File(dbFile.parentFile, "rikka_hub-wal")
-                if (walFile.exists()) {
-                    addFileToZip(zipOut, walFile, "rikka_hub-wal")
-                }
-
-                val shmFile = File(dbFile.parentFile, "rikka_hub-shm")
-                if (shmFile.exists()) {
-                    addFileToZip(zipOut, shmFile, "rikka_hub-shm")
-                }
-            }
-
-            // Backup app files
-            if (config.items.contains(WebDavConfig.BackupItem.FILES)) {
-                val uploadFolder = File(context.filesDir, FileFolders.UPLOAD)
-                if (uploadFolder.exists() && uploadFolder.isDirectory) {
-                    Log.i(TAG, "prepareBackupFile: Backing up files from ${uploadFolder.absolutePath}")
-                    uploadFolder.listFiles()?.forEach { file ->
-                        if (file.isFile) {
-                            addFileToZip(zipOut, file, "${FileFolders.UPLOAD}/${file.name}")
-                        }
-                    }
-                } else {
-                    Log.w(TAG, "prepareBackupFile: Upload folder does not exist or is not a directory")
-                }
-
-                val skillsFolder = File(context.filesDir, FileFolders.SKILLS)
-                if (skillsFolder.exists() && skillsFolder.isDirectory) {
-                    Log.i(TAG, "prepareBackupFile: Backing up skills from ${skillsFolder.absolutePath}")
-                    addDirectoryToZip(
-                        zipOut = zipOut,
-                        rootDir = skillsFolder,
-                        currentDir = skillsFolder,
-                        entryPrefix = "${FileFolders.SKILLS}/"
-                    )
-                } else {
-                    Log.w(TAG, "prepareBackupFile: Skills folder does not exist or is not a directory")
-                }
-            }
-        }
-
-        Log.i(
-            TAG,
-            "prepareBackupFile: Created backup file ${backupFile.name} (${backupFile.length().fileSizeToString()})"
-        )
-        backupFile
-    }
-
-    private suspend fun restoreFromBackupFile(backupFile: File, config: WebDavConfig) = withContext(Dispatchers.IO) {
-        Log.i(TAG, "restoreFromBackupFile: Starting restore from ${backupFile.absolutePath}")
-
-        ZipInputStream(FileInputStream(backupFile)).use { zipIn ->
-            var entry: ZipEntry?
-            while (zipIn.nextEntry.also { entry = it } != null) {
-                entry?.let { zipEntry ->
-                    Log.i(TAG, "restoreFromBackupFile: Processing entry ${zipEntry.name}")
-
-                    when (zipEntry.name) {
-                        "settings.json" -> {
-                            val settingsJson = zipIn.readBytes().toString(Charsets.UTF_8)
-                            Log.i(TAG, "restoreFromBackupFile: Restoring settings")
-                            try {
-                                val migratedJson = SettingsJsonMigrator.migrate(settingsJson)
-                                val settings = json.decodeFromString<Settings>(migratedJson)
-                                settingsStore.update(settings)
-                                Log.i(TAG, "restoreFromBackupFile: Settings restored successfully")
-                            } catch (e: Exception) {
-                                Log.e(TAG, "restoreFromBackupFile: Failed to restore settings", e)
-                                throw Exception("Failed to restore settings: ${e.message}")
-                            }
-                        }
-
-                        "rikka_hub.db", "rikka_hub-wal", "rikka_hub-shm" -> {
-                            if (config.items.contains(WebDavConfig.BackupItem.DATABASE)) {
-                                val dbFile = when (zipEntry.name) {
-                                    "rikka_hub.db" -> context.getDatabasePath("rikka_hub")
-                                    "rikka_hub-wal" -> File(
-                                        context.getDatabasePath("rikka_hub").parentFile,
-                                        "rikka_hub-wal"
-                                    )
-
-                                    "rikka_hub-shm" -> File(
-                                        context.getDatabasePath("rikka_hub").parentFile,
-                                        "rikka_hub-shm"
-                                    )
-
-                                    else -> null
-                                }
-
-                                dbFile?.let { targetFile ->
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restoring ${zipEntry.name} to ${targetFile.absolutePath}"
-                                    )
-                                    targetFile.parentFile?.mkdirs()
-                                    FileOutputStream(targetFile).use { outputStream ->
-                                        zipIn.copyTo(outputStream)
-                                    }
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restored ${zipEntry.name} (${targetFile.length()} bytes)"
-                                    )
-                                }
-                            }
-                        }
-
-                        else -> {
-                            if (config.items.contains(WebDavConfig.BackupItem.FILES) &&
-                                zipEntry.name.startsWith("${FileFolders.UPLOAD}/")
-                            ) {
-                                val fileName = zipEntry.name.substringAfter("${FileFolders.UPLOAD}/")
-                                if (fileName.isNotEmpty()) {
-                                    val uploadFolder = File(context.filesDir, FileFolders.UPLOAD)
-                                    if (!uploadFolder.exists()) {
-                                        uploadFolder.mkdirs()
-                                        Log.i(TAG, "restoreFromBackupFile: Created upload directory")
-                                    }
-
-                                    val targetFile = File(uploadFolder, fileName)
-                                    Log.i(
-                                        TAG,
-                                        "restoreFromBackupFile: Restoring file ${zipEntry.name} to ${targetFile.absolutePath}"
-                                    )
-
-                                    try {
-                                        FileOutputStream(targetFile).use { outputStream ->
-                                            zipIn.copyTo(outputStream)
-                                        }
-                                        Log.i(
-                                            TAG,
-                                            "restoreFromBackupFile: Restored ${zipEntry.name} (${targetFile.length()} bytes)"
-                                        )
-                                    } catch (e: Exception) {
-                                        Log.e(TAG, "restoreFromBackupFile: Failed to restore file ${zipEntry.name}", e)
-                                        throw Exception("Failed to restore file ${zipEntry.name}: ${e.message}")
-                                    }
-                                }
-                            } else if (config.items.contains(WebDavConfig.BackupItem.FILES) &&
-                                zipEntry.name.startsWith("${FileFolders.SKILLS}/")
-                            ) {
-                                restoreSkillEntry(zipIn, zipEntry.name)
-                            } else {
-                                Log.i(TAG, "restoreFromBackupFile: Skipping entry ${zipEntry.name}")
-                            }
-                        }
-                    }
-
-                    zipIn.closeEntry()
-                }
-            }
-        }
-
-        Log.i(TAG, "restoreFromBackupFile: Restore completed successfully")
-    }
-
-    private fun addFileToZip(zipOut: ZipOutputStream, file: File, entryName: String) {
-        FileInputStream(file).use { fis ->
-            val zipEntry = ZipEntry(entryName)
-            zipOut.putNextEntry(zipEntry)
-            fis.copyTo(zipOut)
-            zipOut.closeEntry()
-            Log.d(TAG, "addFileToZip: Added $entryName (${file.length()} bytes) to zip")
-        }
-    }
-
-    private fun addDirectoryToZip(
-        zipOut: ZipOutputStream,
-        rootDir: File,
-        currentDir: File,
-        entryPrefix: String,
-    ) {
-        currentDir.listFiles()?.forEach { file ->
-            if (file.isDirectory) {
-                addDirectoryToZip(
-                    zipOut = zipOut,
-                    rootDir = rootDir,
-                    currentDir = file,
-                    entryPrefix = entryPrefix,
-                )
-            } else if (file.isFile) {
-                val relativePath = file.relativeTo(rootDir).invariantSeparatorsPath
-                addFileToZip(zipOut, file, "$entryPrefix$relativePath")
-            }
-        }
-    }
-
-    private fun restoreSkillEntry(zipIn: ZipInputStream, entryName: String) {
-        val relativePath = entryName.substringAfter("${FileFolders.SKILLS}/")
-        val skillName = relativePath.substringBefore('/', missingDelimiterValue = "")
-        val skillRelativePath = relativePath.substringAfter('/', missingDelimiterValue = "")
-
-        if (skillName.isBlank() || skillRelativePath.isBlank()) {
-            Log.w(TAG, "restoreFromBackupFile: Invalid skill entry $entryName")
-            return
-        }
-
-        val skillsRoot = File(context.filesDir, FileFolders.SKILLS).apply { mkdirs() }
-        val skillDir = SkillPaths.resolveSkillDir(skillsRoot, skillName)
-            ?: throw Exception("Invalid skill directory: $entryName")
-        val targetFile = SkillPaths.resolveSkillFile(skillDir, skillRelativePath)
-            ?: throw Exception("Invalid skill file path: $entryName")
-
-        skillDir.mkdirs()
-        targetFile.parentFile?.mkdirs()
-
-        try {
-            FileOutputStream(targetFile).use { outputStream ->
-                zipIn.copyTo(outputStream)
-            }
-            Log.i(TAG, "restoreFromBackupFile: Restored skill file $entryName (${targetFile.length()} bytes)")
-        } catch (e: Exception) {
-            Log.e(TAG, "restoreFromBackupFile: Failed to restore skill file $entryName", e)
-            throw Exception("Failed to restore skill file $entryName: ${e.message}")
-        }
-    }
-
-    private fun addVirtualFileToZip(zipOut: ZipOutputStream, name: String, content: String) {
-        val zipEntry = ZipEntry(name)
-        zipOut.putNextEntry(zipEntry)
-        zipOut.write(content.toByteArray())
-        zipOut.closeEntry()
-        Log.i(TAG, "addVirtualFileToZip: $name (${content.length} bytes)")
-    }
 }
 
 data class WebDavBackupItem(
@@ -384,4 +121,3 @@ data class WebDavBackupItem(
     val size: Long,
     val lastModified: Instant,
 )
-

--- a/app/src/main/java/com/eterultimate/eteruee/di/DataSourceModule.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/di/DataSourceModule.kt
@@ -1,10 +1,5 @@
 ﻿package com.eterultimate.eteruee.di
 
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.sqlite.SQLiteConnection
-import androidx.sqlite.db.SupportSQLiteDatabase
-import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import android.content.Context
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -28,14 +23,9 @@ import com.eterultimate.eteruee.data.api.SponsorAPI
 import com.eterultimate.eteruee.data.datastore.DEFAULT_ETERUEE_OFFICIAL_API_BASE_URL
 import com.eterultimate.eteruee.data.datastore.SettingsStore
 import com.eterultimate.eteruee.data.db.AppDatabase
+import com.eterultimate.eteruee.data.db.AppDatabaseFactory
+import com.eterultimate.eteruee.data.sync.BackupManager
 import com.eterultimate.eteruee.data.db.fts.MessageFtsManager
-import com.eterultimate.eteruee.data.db.fts.MessageFtsSchema
-import com.eterultimate.eteruee.data.db.migrations.Migration_6_7
-import com.eterultimate.eteruee.data.db.migrations.MIGRATION_17_18
-import com.eterultimate.eteruee.data.db.migrations.Migration_11_12
-import com.eterultimate.eteruee.data.db.migrations.Migration_13_14
-import com.eterultimate.eteruee.data.db.migrations.Migration_14_15
-import com.eterultimate.eteruee.data.db.migrations.Migration_15_16
 import com.eterultimate.eteruee.data.ai.mcp.McpManager
 import com.eterultimate.eteruee.data.sync.webdav.WebDavSync
 import com.eterultimate.eteruee.search.SearchService
@@ -58,20 +48,7 @@ val dataSourceModule = module {
 
     single {
         val context: Context = get()
-        Room.databaseBuilder(context, AppDatabase::class.java, "rikka_hub")
-            .setDriver(BundledSQLiteDriver())
-            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(Migration_6_7, Migration_11_12, Migration_13_14, Migration_14_15, Migration_15_16, MIGRATION_17_18)
-            .addCallback(object : RoomDatabase.Callback() {
-                override fun onOpen(db: SupportSQLiteDatabase) {
-                    MessageFtsSchema.ensure(db)
-                }
-
-                override fun onOpen(connection: SQLiteConnection) {
-                    MessageFtsSchema.ensure(connection)
-                }
-            })
-            .build()
+        AppDatabaseFactory.create(context)
     }
 
     single {
@@ -213,10 +190,11 @@ val dataSourceModule = module {
         ProviderManager(client = get(), context = get())
     }
 
+    single { BackupManager(context = get(), database = get(), settingsStore = get(), json = get()) }
+
     single {
         WebDavSync(
-            settingsStore = get(),
-            json = get(),
+            backupManager = get(),
             context = get(),
             httpClient = get()
         )
@@ -239,8 +217,7 @@ val dataSourceModule = module {
 
     single {
         S3Sync(
-            settingsStore = get(),
-            json = get(),
+            backupManager = get(),
             context = get(),
             httpClient = get()
         )

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/message/ChatMessageTools.kt
@@ -973,20 +973,41 @@ private fun ChainOfThoughtScope.AskUserToolStep(
     val isAnswered = tool.approvalState is ToolApprovalState.Answered
     val arguments = tool.inputAsJson()
 
-    // Parse questions from arguments
-    val questions = remember(arguments) {
-        runCatching {
-            arguments.jsonObject["questions"]?.jsonArray?.map { q ->
-                val obj = q.jsonObject
+    // Parse questions from arguments. Fault-tolerant parsing: models/proxies may emit
+    // double-encoded arrays ("[{...}]" instead of [{...}]) or object-shaped options
+    // ({"text": ...}). A single malformed question must not discard the whole list,
+    // which rendered a blank card with a submittable empty answer (rikkahub#1848).
+    val argumentsObject = remember(arguments) { runCatching { arguments.jsonObject }.getOrNull() }
+    val questions = remember(argumentsObject) {
+        val raw = argumentsObject?.get("questions")
+        val arr: JsonArray? = raw as? JsonArray
+            ?: (raw as? JsonPrimitive)?.let {
+                runCatching { JsonInstant.parseToJsonElement(it.content).jsonArray }.getOrNull()
+            }
+        arr.orEmpty().mapNotNull { q ->
+            val obj = runCatching { q.jsonObject }.getOrNull() ?: return@mapNotNull null
+            runCatching {
                 AskUserQuestion(
                     id = obj["id"]?.jsonPrimitive?.contentOrNull ?: "",
                     question = obj["question"]?.jsonPrimitive?.contentOrNull ?: "",
-                    options = obj["options"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList(),
+                    options = (obj["options"] as? JsonArray)?.mapNotNull { o ->
+                        when (o) {
+                            is JsonPrimitive -> o.contentOrNull
+                            is JsonObject ->
+                                ((o["text"] ?: o["label"] ?: o["option"]) as? JsonPrimitive)?.contentOrNull
+                            else -> null
+                        }
+                    } ?: emptyList(),
                     selectionType = obj["selection_type"]?.jsonPrimitive?.contentOrNull ?: "text"
                 )
-            } ?: emptyList()
-        }.getOrElse { emptyList() }
+            }.getOrNull()
+        }.filter { it.question.isNotBlank() || it.options.isNotEmpty() }
     }
+    // True when the tool call carried questions but none could be parsed
+    val parseFailed = questions.isEmpty() && argumentsObject?.containsKey("questions") == true
+
+    // Fallback free-text answer used when parsing failed
+    var rawAnswer by remember { mutableStateOf("") }
 
     // Track answers for text/single questions
     val answers = remember { mutableStateMapOf<String, String>() }
@@ -1142,6 +1163,24 @@ private fun ChainOfThoughtScope.AskUserToolStep(
                     }
                 }
 
+                if (parseFailed && isPending && onToolAnswer != null) {
+                    // Fallback UI: never leave the user with an unusable blank card (#1848)
+                    Text(
+                        text = "Failed to parse question arguments / 问题参数解析失败，请直接文字回答：",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    OutlinedTextField(
+                        value = rawAnswer,
+                        onValueChange = { rawAnswer = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        textStyle = MaterialTheme.typography.bodySmall,
+                        singleLine = false,
+                        minLines = 1,
+                        maxLines = 4,
+                    )
+                }
+
                 // Submit button
                 if (isPending && onToolAnswer != null) {
                     FilledTonalButton(
@@ -1154,14 +1193,22 @@ private fun ChainOfThoughtScope.AskUserToolStep(
                                             else -> put(q.id, JsonPrimitive(answers[q.id] ?: ""))
                                         }
                                     }
+                                    if (questions.isEmpty()) {
+                                        put("_raw", JsonPrimitive(rawAnswer))
+                                    }
                                 })
                             }
                             onToolAnswer(tool.toolCallId, answerPayload.toString())
                         },
-                        enabled = questions.all { q ->
-                            when (q.selectionType) {
-                                "multi" -> !multiAnswers[q.id].isNullOrEmpty()
-                                else -> !answers[q.id].isNullOrBlank()
+                        enabled = if (questions.isEmpty()) {
+                            // Guard against the vacuous-truth submit of an empty list (#1848)
+                            rawAnswer.isNotBlank()
+                        } else {
+                            questions.all { q ->
+                                when (q.selectionType) {
+                                    "multi" -> !multiAnswers[q.id].isNullOrEmpty()
+                                    else -> !answers[q.id].isNullOrBlank()
+                                }
                             }
                         },
                         modifier = Modifier.align(Alignment.End),

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/HighlightCodeBlock.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/richtext/HighlightCodeBlock.kt
@@ -125,10 +125,10 @@ fun HighlightCodeBlock(
         contract = ActivityResultContracts.CreateDocument("*/*")
     ) { uri: Uri? ->
         uri?.let {
-            scope.launch {
+            scope.launch(Dispatchers.IO) {
                 try {
-                    context.contentResolver.openOutputStream(it)?.use { outputStream ->
-                        outputStream.write(code.toByteArray())
+                    context.contentResolver.openOutputStream(it, "wt")?.use { outputStream ->
+                        outputStream.write(code.toByteArray(Charsets.UTF_8))
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/ui/UIAvatar.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/ui/UIAvatar.kt
@@ -2,6 +2,7 @@ package com.eterultimate.eteruee.ui.components.ui
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.background
@@ -121,7 +122,7 @@ fun UIAvatar(
     )
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
+        contract = ActivityResultContracts.PickVisualMedia()
     ) { uri: Uri? ->
         uri?.let { selectedUri ->
             val tempFile = File(context.appTempFolder, "avatar_pick_${System.currentTimeMillis()}.jpg")
@@ -228,7 +229,9 @@ fun UIAvatar(
                     Button(
                         onClick = {
                             showPickOption = false
-                            imagePickerLauncher.launch("image/*")
+                            imagePickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
                         },
                         modifier = Modifier.fillMaxWidth()
                     ) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/components/ui/UIAvatar.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/components/ui/UIAvatar.kt
@@ -2,7 +2,6 @@ package com.eterultimate.eteruee.ui.components.ui
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.background
@@ -122,7 +121,7 @@ fun UIAvatar(
     )
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia()
+        contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let { selectedUri ->
             val tempFile = File(context.appTempFolder, "avatar_pick_${System.currentTimeMillis()}.jpg")
@@ -229,9 +228,7 @@ fun UIAvatar(
                     Button(
                         onClick = {
                             showPickOption = false
-                            imagePickerLauncher.launch(
-                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                            )
+                            imagePickerLauncher.launch("image/*")
                         },
                         modifier = Modifier.fillMaxWidth()
                     ) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/AssistantMemoryPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/AssistantMemoryPage.kt
@@ -331,12 +331,7 @@ private fun MemoryItem(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 Text(
-                    text = "#${memory.id}",
-                    style = MaterialTheme.typography.titleMediumEmphasized,
-                )
-                Text(
                     text = memory.content,
-
                     maxLines = 5,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/BackgroundPicker.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/BackgroundPicker.kt
@@ -2,6 +2,7 @@
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -44,7 +45,7 @@ fun BackgroundPicker(
     var urlInput by remember { mutableStateOf("") }
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
+        contract = ActivityResultContracts.PickVisualMedia()
     ) { uri: Uri? ->
         uri?.let {
             val localUris = filesManager.createChatFilesByContents(listOf(it))
@@ -126,7 +127,9 @@ fun BackgroundPicker(
                     Button(
                         onClick = {
                             showPickOption = false
-                            imagePickerLauncher.launch("image/*")
+                            imagePickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
                         },
                         modifier = Modifier.fillMaxWidth()
                     ) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/BackgroundPicker.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/assistant/detail/BackgroundPicker.kt
@@ -2,7 +2,6 @@
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -45,7 +44,7 @@ fun BackgroundPicker(
     var urlInput by remember { mutableStateOf("") }
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia()
+        contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
             val localUris = filesManager.createChatFilesByContents(listOf(it))
@@ -127,9 +126,7 @@ fun BackgroundPicker(
                     Button(
                         onClick = {
                             showPickOption = false
-                            imagePickerLauncher.launch(
-                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                            )
+                            imagePickerLauncher.launch("image/*")
                         },
                         modifier = Modifier.fillMaxWidth()
                     ) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/imggen/ImgGenPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/imggen/ImgGenPage.kt
@@ -2,7 +2,6 @@ package com.eterultimate.eteruee.ui.pages.imggen
 
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -358,7 +357,7 @@ private fun InputBar(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val imagePickerLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) { selectedUris ->
+        rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { selectedUris ->
             if (selectedUris.isNotEmpty()) {
                 scope.launch {
                     val paths = selectedUris.mapNotNull { uri ->
@@ -453,11 +452,7 @@ private fun InputBar(
             }
 
             IconButton(
-                onClick = {
-                    imagePickerLauncher.launch(
-                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                    )
-                }
+                onClick = { imagePickerLauncher.launch("image/*") }
             ) {
                 Icon(
                     imageVector = HugeIcons.Add01,

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/imggen/ImgGenPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/imggen/ImgGenPage.kt
@@ -2,6 +2,7 @@ package com.eterultimate.eteruee.ui.pages.imggen
 
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -357,7 +358,7 @@ private fun InputBar(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val imagePickerLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { selectedUris ->
+        rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) { selectedUris ->
             if (selectedUris.isNotEmpty()) {
                 scope.launch {
                     val paths = selectedUris.mapNotNull { uri ->
@@ -452,7 +453,11 @@ private fun InputBar(
             }
 
             IconButton(
-                onClick = { imagePickerLauncher.launch("image/*") }
+                onClick = {
+                    imagePickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                }
             ) {
                 Icon(
                     imageVector = HugeIcons.Add01,

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/search/SearchPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/search/SearchPage.kt
@@ -26,6 +26,9 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -135,6 +138,33 @@ fun SearchPage(vm: SearchVM = koinViewModel()) {
                     onSearch = { vm.search() }
                 ),
             )
+
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp),
+            ) {
+                MessageSearchScope.entries.forEachIndexed { index, scope ->
+                    SegmentedButton(
+                        selected = vm.searchScope == scope,
+                        onClick = { vm.onScopeChange(scope) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = MessageSearchScope.entries.size,
+                        ),
+                    ) {
+                        Text(
+                            stringResource(
+                                when (scope) {
+                                    MessageSearchScope.CURRENT_ASSISTANT -> R.string.search_page_scope_current_assistant
+                                    MessageSearchScope.ALL_ASSISTANTS -> R.string.search_page_scope_all_assistants
+                                }
+                            )
+                        )
+                    }
+                }
+            }
 
             Box(modifier = Modifier.weight(1f)) {
                 if (vm.isLoading || vm.isRebuilding) {

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/search/SearchVM.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/search/SearchVM.kt
@@ -1,4 +1,4 @@
-﻿package com.eterultimate.eteruee.ui.pages.search
+package com.eterultimate.eteruee.ui.pages.search
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -8,16 +8,30 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import com.eterultimate.eteruee.data.datastore.SettingsStore
+import com.eterultimate.eteruee.data.datastore.getCurrentAssistant
 import com.eterultimate.eteruee.data.db.fts.MessageSearchResult
 import com.eterultimate.eteruee.data.repository.ConversationRepository
+import kotlin.uuid.Uuid
+
+enum class MessageSearchScope {
+    CURRENT_ASSISTANT,
+    ALL_ASSISTANTS,
+}
 
 class SearchVM(
     private val conversationRepo: ConversationRepository,
+    private val settingsStore: SettingsStore,
 ) : ViewModel() {
     private val _searchQuery = MutableStateFlow("")
+    private var currentAssistantId: Uuid? = null
 
     var searchQuery by mutableStateOf("")
+        private set
+    var searchScope by mutableStateOf(MessageSearchScope.CURRENT_ASSISTANT)
         private set
     var results by mutableStateOf<List<MessageSearchResult>>(emptyList())
         private set
@@ -34,11 +48,30 @@ class SearchVM(
                 .debounce(300L)
                 .collectLatest { query -> performSearch(query) }
         }
+        viewModelScope.launch {
+            settingsStore.settingsFlow
+                .map { it.getCurrentAssistant().id }
+                .distinctUntilChanged()
+                .collect { assistantId ->
+                    currentAssistantId = assistantId
+                    if (searchScope == MessageSearchScope.CURRENT_ASSISTANT) {
+                        performSearch(searchQuery)
+                    }
+                }
+        }
     }
 
     fun onQueryChange(query: String) {
         searchQuery = query
         _searchQuery.value = query
+    }
+
+    fun onScopeChange(scope: MessageSearchScope) {
+        if (searchScope == scope) return
+        searchScope = scope
+        viewModelScope.launch {
+            performSearch(searchQuery)
+        }
     }
 
     fun search() {
@@ -62,16 +95,19 @@ class SearchVM(
     }
 
     private suspend fun performSearch(query: String) {
-        if (query.isBlank()) {
+        val assistantId = when (searchScope) {
+            MessageSearchScope.CURRENT_ASSISTANT -> currentAssistantId
+            MessageSearchScope.ALL_ASSISTANTS -> null
+        }
+        if (query.isBlank() || (searchScope == MessageSearchScope.CURRENT_ASSISTANT && assistantId == null)) {
             results = emptyList()
             return
         }
         isLoading = true
         try {
-            results = conversationRepo.searchMessages(query)
+            results = conversationRepo.searchMessages(query, assistantId)
         } finally {
             isLoading = false
         }
     }
 }
-

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingFilesPage.kt
@@ -4,6 +4,7 @@ import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Image02
 import me.rerere.hugeicons.stroke.Clean
 import me.rerere.hugeicons.stroke.Delete01
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
@@ -24,15 +26,20 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -59,7 +66,9 @@ import com.eterultimate.eteruee.ui.context.LocalToaster
 import com.eterultimate.eteruee.ui.theme.CustomColors
 import org.koin.compose.koinInject
 import java.io.File
+import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingFilesPage(
     filesManager: FilesManager = koinInject(),
@@ -78,7 +87,8 @@ fun SettingFilesPage(
 
     var selectedFolder by remember { mutableStateOf(FileFolders.UPLOAD) }
     var pendingDelete by remember { mutableStateOf<ManagedFileEntity?>(null) }
-    var showCleanDialog by remember { mutableStateOf(false) }
+    var showCleanSheet by remember { mutableStateOf(false) }
+    var selectedCleanRange by remember { mutableStateOf(CleanRange.DAYS_7) }
     val files by filesManager.observe(selectedFolder).collectAsState(initial = emptyList())
 
     if (pendingDelete != null) {
@@ -112,30 +122,32 @@ fun SettingFilesPage(
         )
     }
 
-    if (showCleanDialog) {
-        AlertDialog(
-            onDismissRequest = { showCleanDialog = false },
-            title = { Text(stringResource(R.string.setting_files_page_clean_title)) },
-            text = { Text(stringResource(R.string.setting_files_page_clean_confirmation)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showCleanDialog = false
-                        scope.launch {
-                            val ok = filesManager.deleteAll(selectedFolder)
-                            toaster.show(if (ok) cleanedToast else cleanFailedToast)
-                        }
-                    }
-                ) {
-                    Text(stringResource(R.string.setting_files_page_clean_action))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showCleanDialog = false }) {
-                    Text(stringResource(R.string.setting_files_page_cancel_action))
-                }
-            }
+    if (showCleanSheet) {
+        val sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
         )
+        ModalBottomSheet(
+            onDismissRequest = { showCleanSheet = false },
+            sheetState = sheetState,
+        ) {
+            CleanFilesSheet(
+                selectedRange = selectedCleanRange,
+                onRangeSelected = { selectedCleanRange = it },
+                onClean = {
+                    showCleanSheet = false
+                    scope.launch {
+                        val ok = selectedCleanRange.days?.let { days ->
+                            filesManager.deleteOlderThan(
+                                folder = selectedFolder,
+                                cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days.toLong()),
+                            )
+                        } ?: filesManager.deleteAll(selectedFolder)
+                        toaster.show(if (ok) cleanedToast else cleanFailedToast)
+                    }
+                },
+            )
+        }
     }
 
     Scaffold(
@@ -145,7 +157,7 @@ fun SettingFilesPage(
                 navigationIcon = { BackButton() },
                 actions = {
                     IconButton(
-                        onClick = { showCleanDialog = true },
+                        onClick = { showCleanSheet = true },
                         enabled = files.isNotEmpty(),
                     ) {
                         Icon(
@@ -208,6 +220,70 @@ fun SettingFilesPage(
                     }
                 }
             }
+        }
+    }
+}
+
+private enum class CleanRange(val days: Int?) {
+    DAYS_7(7),
+    DAYS_14(14),
+    DAYS_30(30),
+    ALL(null),
+}
+
+@Composable
+private fun CleanFilesSheet(
+    selectedRange: CleanRange,
+    onRangeSelected: (CleanRange) -> Unit,
+    onClean: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.setting_files_page_clean_title),
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Text(
+            text = stringResource(R.string.setting_files_page_clean_range_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
+        )
+
+        CleanRange.entries.forEach { range ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onRangeSelected(range) }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RadioButton(
+                    selected = selectedRange == range,
+                    onClick = { onRangeSelected(range) },
+                )
+                Text(
+                    text = range.days?.let {
+                        stringResource(R.string.setting_files_page_clean_older_than_days, it)
+                    } ?: stringResource(R.string.setting_files_page_clean_all),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+        }
+
+        TextButton(
+            onClick = onClean,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+        ) {
+            Text(stringResource(R.string.setting_files_page_clean_action))
         }
     }
 }

--- a/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingPreferencesNetworkPage.kt
+++ b/app/src/main/java/com/eterultimate/eteruee/ui/pages/setting/SettingPreferencesNetworkPage.kt
@@ -51,6 +51,7 @@ import com.eterultimate.eteruee.R
 import com.eterultimate.eteruee.data.network.toProxyOrNull
 import com.eterultimate.eteruee.ui.components.nav.BackButton
 import com.eterultimate.eteruee.ui.components.ui.CardGroup
+import com.eterultimate.eteruee.ui.components.ui.Switch
 import com.eterultimate.eteruee.ui.context.LocalToaster
 import com.eterultimate.eteruee.ui.theme.CustomColors
 import com.eterultimate.eteruee.utils.plus
@@ -275,6 +276,34 @@ fun SettingPreferencesNetworkPage(vm: SettingVM = koinViewModel()) {
             contentPadding = contentPadding + PaddingValues(8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            item {
+                CardGroup(
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                ) {
+                    item(
+                        headlineContent = {
+                            Text(stringResource(R.string.setting_page_preferences_network_auto_retry))
+                        },
+                        supportingContent = {
+                            Text(stringResource(R.string.setting_page_preferences_network_auto_retry_desc))
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = settings.networkSetting.enableAutoRetry,
+                                onCheckedChange = { enabled ->
+                                    vm.updateSettings(
+                                        settings.copy(
+                                            networkSetting = settings.networkSetting.copy(
+                                                enableAutoRetry = enabled,
+                                            ),
+                                        )
+                                    )
+                                },
+                            )
+                        },
+                    )
+                }
+            }
             item {
                 CardGroup(
                     modifier = Modifier.padding(horizontal = 8.dp),

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1289,4 +1289,6 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_files_page_clean_all">すべてのファイル</string>
   <string name="setting_files_page_clean_older_than_days">%1$d日以上前</string>
   <string name="setting_files_page_clean_range_description">完全に削除するファイルを選択してください。この操作は元に戻せません。</string>
+  <string name="setting_page_preferences_network_auto_retry">自動再試行</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">ネットワークエラー時、モデルリクエストを最大3回再試行します。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1293,4 +1293,6 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_page_preferences_network_auto_retry_desc">ネットワークエラー時、モデルリクエストを最大3回再試行します。</string>
   <string name="search_page_scope_current_assistant">現在のアシスタント</string>
   <string name="search_page_scope_all_assistants">すべてのアシスタント</string>
+  <string name="setting_tts_page_playback_speed">読み上げ速度</string>
+  <string name="setting_tts_page_playback_speed_desc">TTS のデフォルト読み上げ速度（0.5x - 2.0x）</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -769,7 +769,7 @@
   <string name="setting_page_built_in_tools_search_desc">Google検索連携を有効化</string>
   <string name="setting_page_built_in_tools_url_context">URLコンテキスト</string>
   <string name="setting_page_built_in_tools_url_context_desc">URLコンテンツ処理を有効化</string>
-  <string name="setting_page_chat_storage">チャット保存</string>
+  <string name="setting_page_chat_storage">ストレージ管理</string>
   <string name="setting_page_chat_storage_desc">%1$d ファイル、%2$.2f MB</string>
   <string name="setting_page_code_display_settings">コード表示</string>
   <string name="setting_page_color_mode">カラーモード</string>
@@ -1286,4 +1286,7 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_provider_page_test_tool_call">ツール呼び出し</string>
   <string name="setting_provider_page_test_tool_called">呼び出し: %1$s  引数: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">ツールが呼び出されませんでした。応答: %s</string>
+  <string name="setting_files_page_clean_all">すべてのファイル</string>
+  <string name="setting_files_page_clean_older_than_days">%1$d日以上前</string>
+  <string name="setting_files_page_clean_range_description">完全に削除するファイルを選択してください。この操作は元に戻せません。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1291,4 +1291,6 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_files_page_clean_range_description">完全に削除するファイルを選択してください。この操作は元に戻せません。</string>
   <string name="setting_page_preferences_network_auto_retry">自動再試行</string>
   <string name="setting_page_preferences_network_auto_retry_desc">ネットワークエラー時、モデルリクエストを最大3回再試行します。</string>
+  <string name="search_page_scope_current_assistant">現在のアシスタント</string>
+  <string name="search_page_scope_all_assistants">すべてのアシスタント</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1293,4 +1293,6 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_page_preferences_network_auto_retry_desc">네트워크 오류 발생 시 모델 요청을 최대 3회 재시도합니다.</string>
   <string name="search_page_scope_current_assistant">현재 어시스턴트</string>
   <string name="search_page_scope_all_assistants">모든 어시스턴트</string>
+  <string name="setting_tts_page_playback_speed">읽기 속도</string>
+  <string name="setting_tts_page_playback_speed_desc">TTS 기본 재생 속도 (0.5x - 2.0x)</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -769,7 +769,7 @@
   <string name="setting_page_built_in_tools_search_desc">Google 검색 통합 활성화</string>
   <string name="setting_page_built_in_tools_url_context">URL 컨텍스트</string>
   <string name="setting_page_built_in_tools_url_context_desc">URL 콘텐츠 처리 활성화</string>
-  <string name="setting_page_chat_storage">채팅 저장 공간</string>
+  <string name="setting_page_chat_storage">저장 공간 관리</string>
   <string name="setting_page_chat_storage_desc">%1$d개 파일, %2$.2f MB</string>
   <string name="setting_page_code_display_settings">코드 표시</string>
   <string name="setting_page_color_mode">색상 모드</string>
@@ -1286,4 +1286,7 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_provider_page_test_tool_call">도구 호출</string>
   <string name="setting_provider_page_test_tool_called">호출: %1$s  인수: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">도구가 호출되지 않음, 응답: %s</string>
+  <string name="setting_files_page_clean_all">모든 파일</string>
+  <string name="setting_files_page_clean_older_than_days">%1$d일 이상 지난 파일</string>
+  <string name="setting_files_page_clean_range_description">영구적으로 삭제할 파일을 선택하세요. 이 작업은 되돌릴 수 없습니다.</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1289,4 +1289,6 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_files_page_clean_all">모든 파일</string>
   <string name="setting_files_page_clean_older_than_days">%1$d일 이상 지난 파일</string>
   <string name="setting_files_page_clean_range_description">영구적으로 삭제할 파일을 선택하세요. 이 작업은 되돌릴 수 없습니다.</string>
+  <string name="setting_page_preferences_network_auto_retry">자동 재시도</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">네트워크 오류 발생 시 모델 요청을 최대 3회 재시도합니다.</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1291,4 +1291,6 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_files_page_clean_range_description">영구적으로 삭제할 파일을 선택하세요. 이 작업은 되돌릴 수 없습니다.</string>
   <string name="setting_page_preferences_network_auto_retry">자동 재시도</string>
   <string name="setting_page_preferences_network_auto_retry_desc">네트워크 오류 발생 시 모델 요청을 최대 3회 재시도합니다.</string>
+  <string name="search_page_scope_current_assistant">현재 어시스턴트</string>
+  <string name="search_page_scope_all_assistants">모든 어시스턴트</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1291,4 +1291,6 @@
   <string name="setting_files_page_clean_range_description">Выберите файлы для окончательного удаления. Это действие нельзя отменить.</string>
   <string name="setting_page_preferences_network_auto_retry">Автоповтор</string>
   <string name="setting_page_preferences_network_auto_retry_desc">Повторять запросы модели до 3 раз при сетевых ошибках.</string>
+  <string name="search_page_scope_current_assistant">Текущий ассистент</string>
+  <string name="search_page_scope_all_assistants">Все ассистенты</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1289,4 +1289,6 @@
   <string name="setting_files_page_clean_all">Все файлы</string>
   <string name="setting_files_page_clean_older_than_days">Старше %1$d дней</string>
   <string name="setting_files_page_clean_range_description">Выберите файлы для окончательного удаления. Это действие нельзя отменить.</string>
+  <string name="setting_page_preferences_network_auto_retry">Автоповтор</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">Повторять запросы модели до 3 раз при сетевых ошибках.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -769,7 +769,7 @@
   <string name="setting_page_built_in_tools_search_desc">Включить интеграцию с Google Поиском</string>
   <string name="setting_page_built_in_tools_url_context">Контекст URL</string>
   <string name="setting_page_built_in_tools_url_context_desc">Включить обработку содержимого по URL</string>
-  <string name="setting_page_chat_storage">Хранилище чатов</string>
+  <string name="setting_page_chat_storage">Управление хранилищем</string>
   <string name="setting_page_chat_storage_desc">%1$d файлов, %2$.2f МБ</string>
   <string name="setting_page_code_display_settings">Отображение кода</string>
   <string name="setting_page_color_mode">Цветовая схема</string>
@@ -1286,4 +1286,7 @@
   <string name="setting_provider_page_test_tool_call">Вызов инструмента</string>
   <string name="setting_provider_page_test_tool_called">Вызвано: %1$s  Аргументы: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">Инструмент не вызван, ответ: %s</string>
+  <string name="setting_files_page_clean_all">Все файлы</string>
+  <string name="setting_files_page_clean_older_than_days">Старше %1$d дней</string>
+  <string name="setting_files_page_clean_range_description">Выберите файлы для окончательного удаления. Это действие нельзя отменить.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1293,4 +1293,6 @@
   <string name="setting_page_preferences_network_auto_retry_desc">Повторять запросы модели до 3 раз при сетевых ошибках.</string>
   <string name="search_page_scope_current_assistant">Текущий ассистент</string>
   <string name="search_page_scope_all_assistants">Все ассистенты</string>
+  <string name="setting_tts_page_playback_speed">Скорость чтения</string>
+  <string name="setting_tts_page_playback_speed_desc">Скорость воспроизведения TTS по умолчанию (0,5x - 2,0x)</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1359,4 +1359,6 @@
   <string name="setting_files_page_clean_all">所有檔案</string>
   <string name="setting_files_page_clean_older_than_days">%1$d 天前</string>
   <string name="setting_files_page_clean_range_description">選擇要永久刪除的檔案。此操作無法復原。</string>
+  <string name="setting_page_preferences_network_auto_retry">自動重試</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">發生網路錯誤時自動重試模型請求，最多重試 3 次。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1361,4 +1361,6 @@
   <string name="setting_files_page_clean_range_description">選擇要永久刪除的檔案。此操作無法復原。</string>
   <string name="setting_page_preferences_network_auto_retry">自動重試</string>
   <string name="setting_page_preferences_network_auto_retry_desc">發生網路錯誤時自動重試模型請求，最多重試 3 次。</string>
+  <string name="search_page_scope_current_assistant">目前助手</string>
+  <string name="search_page_scope_all_assistants">全部助手</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -777,7 +777,7 @@
   <string name="setting_page_built_in_tools_search_desc">啟用 Google 搜尋整合</string>
   <string name="setting_page_built_in_tools_url_context">URL 上下文</string>
   <string name="setting_page_built_in_tools_url_context_desc">啟用 URL 內容處理</string>
-  <string name="setting_page_chat_storage">聊天記錄儲存</string>
+  <string name="setting_page_chat_storage">儲存空間管理</string>
   <string name="setting_page_chat_storage_desc">%1$d 個檔案，%2$.2f MB</string>
   <string name="setting_page_code_display_settings">程式碼顯示</string>
   <string name="setting_page_color_mode">顏色模式</string>
@@ -1356,4 +1356,7 @@
 <string name="theme_name_chatgpt">ChatGPT 風格</string>
 <string name="theme_name_gemini">Gemini 風格</string>
 <string name="theme_name_hitech">HiTech</string>
+  <string name="setting_files_page_clean_all">所有檔案</string>
+  <string name="setting_files_page_clean_older_than_days">%1$d 天前</string>
+  <string name="setting_files_page_clean_range_description">選擇要永久刪除的檔案。此操作無法復原。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1363,4 +1363,6 @@
   <string name="setting_page_preferences_network_auto_retry_desc">發生網路錯誤時自動重試模型請求，最多重試 3 次。</string>
   <string name="search_page_scope_current_assistant">目前助手</string>
   <string name="search_page_scope_all_assistants">全部助手</string>
+  <string name="setting_tts_page_playback_speed">朗讀速度</string>
+  <string name="setting_tts_page_playback_speed_desc">TTS 預設朗讀速度（0.5x - 2.0x）</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1380,4 +1380,6 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
 <string name="theme_name_chatgpt">ChatGPT 风格</string>
 <string name="theme_name_gemini">Gemini 风格</string>
 <string name="theme_name_hitech">HiTech</string>
+  <string name="search_page_scope_current_assistant">当前助手</string>
+  <string name="search_page_scope_all_assistants">所有助手</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -704,9 +704,12 @@
   <string name="setting_display_page_volume_key_scroll_title">音量键翻页</string>
   <string name="setting_files_page_cancel_action">取消</string>
   <string name="setting_files_page_clean_action">清理</string>
+  <string name="setting_files_page_clean_all">全部文件</string>
   <string name="setting_files_page_clean_confirmation">将永久删除此分类中的全部文件，此操作无法撤销。</string>
   <string name="setting_files_page_clean_content_description">清理文件</string>
   <string name="setting_files_page_clean_failed_toast">部分文件清理失败</string>
+  <string name="setting_files_page_clean_older_than_days">%1$d 天前</string>
+  <string name="setting_files_page_clean_range_description">选择要永久删除的文件。此操作无法撤销。</string>
   <string name="setting_files_page_clean_title">清理文件？</string>
   <string name="setting_files_page_cleaned_toast">文件已清理</string>
   <string name="setting_files_page_delete_action">删除</string>
@@ -786,7 +789,7 @@
   <string name="setting_page_built_in_tools_search_desc">启用 Google 搜索集成</string>
   <string name="setting_page_built_in_tools_url_context">URL 上下文</string>
   <string name="setting_page_built_in_tools_url_context_desc">启用 URL 内容处理</string>
-  <string name="setting_page_chat_storage">聊天记录存储</string>
+  <string name="setting_page_chat_storage">存储管理</string>
   <string name="setting_page_chat_storage_desc">%1$d 个文件，%2$.2f MB</string>
   <string name="setting_page_code_display_settings">代码显示</string>
   <string name="setting_page_color_mode">颜色模式</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1370,6 +1370,8 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="chat_generation_network_timeout">连接超时</string>
   <string name="chat_generation_network_unreachable">无法连接到服务器</string>
   <string name="chat_generation_network_disconnected">网络连接已断开</string>
+  <string name="setting_page_preferences_network_auto_retry">自动重试</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">发生网络错误时自动重试模型请求，最多重试 3 次。</string>
   <string name="setting_provider_page_test_non_streaming">非流式</string>
   <string name="setting_provider_page_test_streaming">流式</string>
   <string name="setting_provider_page_test_tool_call">工具调用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -826,6 +826,8 @@
   <string name="setting_page_preferences_network_proxy">Proxy</string>
   <string name="setting_page_preferences_network_proxy_desc">Supports HTTP and SOCKS5 proxy URLs. Leave blank to use system settings.</string>
   <string name="setting_page_preferences_network_proxy_invalid">Enter a valid proxy URL with a host and port.</string>
+  <string name="setting_page_preferences_network_auto_retry">Automatic retry</string>
+  <string name="setting_page_preferences_network_auto_retry_desc">Retry model requests up to 3 times when network errors occur.</string>
   <string name="setting_page_network">Network</string>
   <string name="setting_page_network_desc">Configure user agent and proxy</string>
   <string name="setting_page_mcp_desc">Configure MCP Servers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1364,5 +1364,7 @@
 <string name="theme_name_chatgpt">ChatGPT Style</string>
 <string name="theme_name_gemini">Gemini Style</string>
 <string name="theme_name_hitech">HiTech</string>
+  <string name="search_page_scope_current_assistant">Current Assistant</string>
+  <string name="search_page_scope_all_assistants">All Assistants</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,9 +706,12 @@
   <string name="setting_display_page_volume_key_scroll_title">Volume Key Page Scroll</string>
   <string name="setting_files_page_cancel_action">Cancel</string>
   <string name="setting_files_page_clean_action">Clean</string>
+  <string name="setting_files_page_clean_all">All files</string>
   <string name="setting_files_page_clean_confirmation">All files in this category will be permanently deleted. This action cannot be undone.</string>
   <string name="setting_files_page_clean_content_description">Clean files</string>
   <string name="setting_files_page_clean_failed_toast">Some files could not be cleaned</string>
+  <string name="setting_files_page_clean_older_than_days">Older than %1$d days</string>
+  <string name="setting_files_page_clean_range_description">Select files to permanently delete. This action cannot be undone.</string>
   <string name="setting_files_page_clean_title">Clean files?</string>
   <string name="setting_files_page_cleaned_toast">Files cleaned</string>
   <string name="setting_files_page_delete_action">Delete</string>
@@ -788,7 +791,7 @@
   <string name="setting_page_built_in_tools_search_desc">Enable Google Search integration</string>
   <string name="setting_page_built_in_tools_url_context">URL Context</string>
   <string name="setting_page_built_in_tools_url_context_desc">Enable URL content processing</string>
-  <string name="setting_page_chat_storage">Chat Storage</string>
+  <string name="setting_page_chat_storage">Storage Management</string>
   <string name="setting_page_chat_storage_desc">%1$d files, %2$.2f MB</string>
   <string name="setting_page_code_display_settings">Code Display</string>
   <string name="setting_page_color_mode">Color Mode</string>

--- a/app/src/test/java/com/eterultimate/eteruee/data/sync/PendingRestoreTest.kt
+++ b/app/src/test/java/com/eterultimate/eteruee/data/sync/PendingRestoreTest.kt
@@ -1,0 +1,177 @@
+package com.eterultimate.eteruee.data.sync
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.IOException
+
+class PendingRestoreTest {
+    @get:Rule val temporary = TemporaryFolder()
+
+    private fun restore() = PendingRestore(
+        File(temporary.root, "restore"), database(), File(temporary.root, "files")
+    )
+
+    private fun database() = File(temporary.root, "databases/rikka_hub")
+
+    private fun write(file: File, contents: String): File {
+        file.parentFile!!.mkdirs()
+        file.writeText(contents)
+        return file
+    }
+
+    private fun stage(restore: PendingRestore): File = restore.createStagingDirectory().also {
+        write(File(it, "payload/database/rikka_hub"), "new database")
+        write(File(it, "payload/files/upload/photo"), "new photo")
+        write(File(it, "settings.json"), "new settings")
+        restore.publish(it)
+    }
+
+    @Test fun publishingDoesNotTouchLiveFiles() {
+        write(database(), "old database")
+        write(File(database().path + "-wal"), "old wal")
+        stage(restore())
+        assertEquals("old database", database().readText())
+        assertEquals("old wal", File(database().path + "-wal").readText())
+        assertFalse(File(temporary.root, "files/upload/photo").exists())
+    }
+
+    @Test fun installsStandaloneDatabaseAndDoesNotReplayOnLaterLaunches() = runBlocking {
+        write(database(), "old database")
+        listOf("-wal", "-shm", "-journal").forEach { write(File(database().path + it), "old") }
+        stage(restore())
+        val restored = restore().apply {
+            assertEquals("new settings", it)
+            assertEquals("new database", database().readText())
+            assertEquals("new photo", File(temporary.root, "files/upload/photo").readText())
+            listOf("-wal", "-shm", "-journal").forEach { suffix ->
+                assertFalse(File(database().path + suffix).exists())
+            }
+        }
+        assertTrue(restored)
+        database().writeText("subsequent user changes")
+        assertFalse(restore().apply { error("Settings must not be applied again") })
+        assertEquals("subsequent user changes", database().readText())
+    }
+
+    @Test fun failedSettingsWriteRestoresOriginalDatabaseAndSidecarsAndCanRetry() = runBlocking {
+        write(database(), "old database")
+        write(File(database().path + "-wal"), "old wal")
+        write(File(temporary.root, "files/upload/photo"), "old photo")
+        stage(restore())
+        try {
+            restore().apply { throw IOException("Disk full") }
+            error("Expected failure")
+        } catch (_: RestoreFailedException) {
+            assertEquals("old database", database().readText())
+            assertEquals("old wal", File(database().path + "-wal").readText())
+            assertEquals("old photo", File(temporary.root, "files/upload/photo").readText())
+        }
+        stage(restore())
+        restore().apply { }
+        assertEquals("new database", database().readText())
+        assertFalse(File(database().path + "-wal").exists())
+    }
+
+    @Test fun failedInitialJournalWriteKeepsOriginalDataAndDoesNotBlockLaterLaunches() = runBlocking {
+        write(database(), "old database")
+        write(File(database().path + "-wal"), "old wal")
+        write(File(temporary.root, "files/upload/photo"), "old photo")
+        stage(restore())
+        // Force a real I/O failure without relying on disk capacity or filesystem permissions.
+        assertTrue(File(temporary.root, "restore/pending/journal.json.tmp").mkdir())
+
+        try {
+            restore().apply { error("Settings must not be applied without a journal") }
+            error("Expected failure")
+        } catch (e: RestoreFailedException) {
+            assertTrue(e.cause is IOException)
+        }
+
+        assertEquals("old database", database().readText())
+        assertEquals("old wal", File(database().path + "-wal").readText())
+        assertEquals("old photo", File(temporary.root, "files/upload/photo").readText())
+        assertFalse(File(temporary.root, "restore/pending").exists())
+        val failed = File(temporary.root, "restore").listFiles()!!.single { it.name.startsWith("failed-") }
+        assertEquals("new database", File(failed, "payload/database/rikka_hub").readText())
+        assertFalse(restore().apply { error("Failed restore must not be replayed") })
+
+        stage(restore())
+        assertTrue(restore().apply { })
+        assertEquals("new database", database().readText())
+    }
+
+    @Test fun invalidJournalAfterInterruptionKeepsOriginalsForRecovery() = runBlocking {
+        write(database(), "old database")
+        stage(restore())
+        try {
+            restore().apply { throw SimulatedProcessDeath() }
+        } catch (_: SimulatedProcessDeath) {
+            // The live database has been replaced, but the original is still needed for recovery.
+        }
+        val pending = File(temporary.root, "restore/pending")
+        File(pending, "journal.json").writeText("invalid journal")
+
+        try {
+            restore().apply { error("Settings must not be applied with an invalid journal") }
+            error("Expected failure")
+        } catch (_: SerializationException) {
+            // Startup must stop because the live files may already have been replaced.
+        }
+
+        assertTrue(pending.isDirectory)
+        assertEquals("old database", File(pending, "originals/database/rikka_hub").readText())
+        assertEquals("new database", database().readText())
+    }
+
+    @Test fun restartResumesInstallationInterruptedBeforeCommit() = runBlocking {
+        write(database(), "old database")
+        write(File(database().path + "-wal"), "old wal")
+        stage(restore())
+        try {
+            // Error bypasses ordinary exception rollback, simulating process loss after file moves.
+            restore().apply { throw SimulatedProcessDeath() }
+        } catch (_: SimulatedProcessDeath) {
+            assertTrue(File(temporary.root, "restore/pending").exists())
+        }
+        restore().apply { assertEquals("new settings", it) }
+        assertEquals("new database", database().readText())
+        assertFalse(File(database().path + "-wal").exists())
+        assertFalse(File(temporary.root, "restore/pending").exists())
+    }
+
+    @Test fun filesOnlyRestoreLeavesDatabaseAndWalUntouched() = runBlocking {
+        write(database(), "old database")
+        write(File(database().path + "-wal"), "old wal")
+        val restore = restore()
+        val staging = restore.createStagingDirectory()
+        write(File(staging, "payload/files/fonts/custom.ttf"), "font")
+        restore.publish(staging)
+        restore.apply { error("No settings in backup") }
+        assertEquals("old database", database().readText())
+        assertEquals("old wal", File(database().path + "-wal").readText())
+        assertEquals("font", File(temporary.root, "files/fonts/custom.ttf").readText())
+    }
+
+    @Test fun cannotReplaceAlreadyPendingRestore() {
+        stage(restore())
+        assertThrows(IllegalStateException::class.java) { restore().createStagingDirectory() }
+    }
+
+    @Test fun rejectsArchiveTraversalPaths() {
+        for (path in listOf("../database", "/absolute", "skills/../../database", "skills/..\\database")) {
+            assertThrows(IllegalArgumentException::class.java) {
+                PendingRestore.resolveInside(temporary.root, path)
+            }
+        }
+    }
+
+    private class SimulatedProcessDeath : Error()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -153,7 +153,7 @@ leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", ve
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
-modelcontextprotocol-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
+modelcontextprotocol-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk-client", version.ref = "mcp" }
 pebble = { module = "io.pebbletemplates:pebble", version.ref = "pebble" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/controller/TtsController.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/controller/TtsController.kt
@@ -25,6 +25,8 @@ import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import java.util.UUID
 
 private const val TAG = "TtsController"
+private const val MAX_SYNTHESIS_ATTEMPTS = 3
+private const val SYNTHESIS_RETRY_BASE_DELAY_MS = 500L
 
 /**
  * TTS 控制器（重构版）
@@ -52,11 +54,10 @@ class TtsController(
     private val queue: java.util.concurrent.ConcurrentLinkedQueue<TtsChunk> = java.util.concurrent.ConcurrentLinkedQueue()
     private val allChunks: MutableList<TtsChunk> = mutableListOf()
     private val cache = java.util.concurrent.ConcurrentHashMap<UUID, kotlinx.coroutines.Deferred<TTSResponse>>()
-    private var lastPrefetchedIndex: Int = -1
 
     // 行为参数
     private val chunkDelayMs = 120L
-    private val prefetchCount = 4
+    private val prefetchCount = 2
 
     // 状态流（保留与旧版兼容的 StateFlow）
     private val _isAvailable = MutableStateFlow(false)
@@ -140,7 +141,6 @@ class TtsController(
         }
 
         if (workerJob?.isActive != true) startWorker()
-        prefetchFrom((_currentChunk.value).coerceAtLeast(0))
     }
 
     private fun internalReset() {
@@ -153,7 +153,6 @@ class TtsController(
         allChunks.clear()
         cache.values.forEach { it.cancel(CancellationException("Reset")) }
         cache.clear()
-        lastPrefetchedIndex = -1
         _isSpeaking.update { false }
         _currentChunk.update { 0 }
         _totalChunks.update { 0 }
@@ -203,7 +202,6 @@ class TtsController(
         allChunks.clear()
         cache.values.forEach { it.cancel(CancellationException("Stopped")) }
         cache.clear()
-        lastPrefetchedIndex = -1
         _isSpeaking.update { false }
         _currentChunk.update { 0 }
         _totalChunks.update { 0 }
@@ -247,8 +245,8 @@ class TtsController(
                         )
                     }
 
-                    // 预取下一窗口
-                    prefetchFrom(chunk.index + 1)
+                    // 仅预取当前分片后的固定窗口
+                    prefetchNextChunks(chunk.index)
 
                     val response = try {
                         awaitOrCreate(chunk, provider)
@@ -282,29 +280,63 @@ class TtsController(
         }
     }
 
-    private fun prefetchFrom(startIndex: Int) {
+    private fun prefetchNextChunks(currentIndex: Int) {
         val provider = currentProvider ?: return
-        val begin = startIndex.coerceAtLeast(lastPrefetchedIndex + 1)
+        val begin = currentIndex + 1
         val endExclusive = (begin + prefetchCount).coerceAtMost(allChunks.size)
         if (begin >= endExclusive) return
 
         for (i in begin until endExclusive) {
             val chunk = allChunks.getOrNull(i) ?: continue
-            cache.computeIfAbsent(chunk.id) {
-                scope.async(Dispatchers.IO) { synthesizer.synthesize(provider, chunk) }
-            }
+            getOrCreateSynthesis(chunk, provider)
         }
-        lastPrefetchedIndex = endExclusive - 1
     }
 
     private suspend fun awaitOrCreate(chunk: TtsChunk, provider: TTSProviderSetting): TTSResponse {
-        val deferred = cache.computeIfAbsent(chunk.id) {
-            scope.async(Dispatchers.IO) { synthesizer.synthesize(provider, chunk) }
-        }
+        val deferred = getOrCreateSynthesis(chunk, provider)
         return try {
             deferred.await()
-        } finally {
-            // 可按需保留缓存（此处保留，便于重播/重试）
+        } catch (e: Exception) {
+            // 避免后续复用已经失败或取消的 Deferred
+            cache.remove(chunk.id, deferred)
+            throw e
+        }
+    }
+
+    private fun getOrCreateSynthesis(
+        chunk: TtsChunk,
+        provider: TTSProviderSetting
+    ): kotlinx.coroutines.Deferred<TTSResponse> {
+        return cache.computeIfAbsent(chunk.id) {
+            scope.async(Dispatchers.IO) {
+                synthesizeWithRetry(provider, chunk)
+            }
+        }
+    }
+
+    private suspend fun synthesizeWithRetry(
+        provider: TTSProviderSetting,
+        chunk: TtsChunk
+    ): TTSResponse {
+        var attempt = 1
+        while (true) {
+            try {
+                return synthesizer.synthesize(provider, chunk)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (attempt >= MAX_SYNTHESIS_ATTEMPTS) throw e
+
+                val retryDelayMs = SYNTHESIS_RETRY_BASE_DELAY_MS * (1L shl (attempt - 1))
+                Log.w(
+                    TAG,
+                    "Synthesis attempt $attempt/$MAX_SYNTHESIS_ATTEMPTS failed for chunk ${chunk.index}; " +
+                            "retrying in ${retryDelayMs}ms",
+                    e
+                )
+                delay(retryDelayMs)
+                attempt++
+            }
         }
     }
     // endregion

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/controller/TtsController.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/controller/TtsController.kt
@@ -21,7 +21,9 @@ import com.eterultimate.eteruee.tts.model.PlaybackState
 import com.eterultimate.eteruee.tts.model.PlaybackStatus
 import com.eterultimate.eteruee.tts.model.TTSResponse
 import com.eterultimate.eteruee.tts.provider.TTSManager
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
+import java.io.IOException
 import java.util.UUID
 
 private const val TAG = "TtsController"
@@ -325,13 +327,13 @@ class TtsController(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                if (attempt >= MAX_SYNTHESIS_ATTEMPTS) throw e
+                if (!e.isRetryableSynthesisError() || attempt >= MAX_SYNTHESIS_ATTEMPTS) throw e
 
                 val retryDelayMs = SYNTHESIS_RETRY_BASE_DELAY_MS * (1L shl (attempt - 1))
                 Log.w(
                     TAG,
                     "Synthesis attempt $attempt/$MAX_SYNTHESIS_ATTEMPTS failed for chunk ${chunk.index}; " +
-                            "retrying in ${retryDelayMs}ms",
+                        "retrying in ${retryDelayMs}ms",
                     e
                 )
                 delay(retryDelayMs)
@@ -340,4 +342,8 @@ class TtsController(
         }
     }
     // endregion
+}
+
+private fun Exception.isRetryableSynthesisError(): Boolean {
+    return this is IOException || this is TTSProviderException && isRetryable
 }

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/TTSProviderException.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/TTSProviderException.kt
@@ -1,0 +1,13 @@
+package com.eterultimate.eteruee.tts.provider
+
+/**
+ * TTS Provider 返回的 HTTP 错误。保留状态码供上层判断是否值得重试。
+ */
+class TTSProviderException(
+    message: String,
+    val statusCode: Int,
+    cause: Throwable? = null
+) : Exception(message, cause) {
+    val isRetryable: Boolean
+        get() = statusCode == 408 || statusCode == 429 || statusCode in 500..599
+}

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/ElevenLabsTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/ElevenLabsTTSProvider.kt
@@ -8,6 +8,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -52,7 +53,10 @@ class ElevenLabsTTSProvider : TTSProvider<TTSProviderSetting.ElevenLabs> {
             val errorBody = response.body?.string()
             Log.e(TAG, "generateSpeech: ${response.code} ${response.message}")
             Log.e(TAG, "generateSpeech: $errorBody")
-            throw Exception("ElevenLabs TTS request failed: ${response.code} ${response.message}")
+            throw TTSProviderException(
+                message = "ElevenLabs TTS request failed: ${response.code} ${response.message}",
+                statusCode = response.code
+            )
         }
 
         val audioData = response.body.bytes()

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/GeminiTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/GeminiTTSProvider.kt
@@ -11,6 +11,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -96,7 +97,13 @@ class GeminiTTSProvider : TTSProvider<TTSProviderSetting.Gemini> {
         val response = httpClient.newCall(httpRequest).execute()
 
         if (!response.isSuccessful) {
-            throw Exception("Gemini TTS request failed: ${response.code} ${response.message}")
+            val statusCode = response.code
+            val statusMessage = response.message
+            response.close()
+            throw TTSProviderException(
+                message = "Gemini TTS request failed: $statusCode $statusMessage",
+                statusCode = statusCode
+            )
         }
 
         val responseJson = response.body.string()

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/GroqTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/GroqTTSProvider.kt
@@ -8,6 +8,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -49,7 +50,10 @@ class GroqTTSProvider : TTSProvider<TTSProviderSetting.Groq> {
         if (!response.isSuccessful) {
             Log.e(TAG, "generateSpeech: ${response.code} ${response.message}")
             Log.e(TAG, "generateSpeech: ${response.body?.string()}")
-            throw Exception("Groq TTS request failed: ${response.code} ${response.message}")
+            throw TTSProviderException(
+                message = "Groq TTS request failed: ${response.code} ${response.message}",
+                statusCode = response.code
+            )
         }
 
         val audioData = response.body.bytes()

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/MiMoTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/MiMoTTSProvider.kt
@@ -14,6 +14,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -102,7 +103,17 @@ internal class MiMoSseProcessor(
                 )
             }
 
-            is SseEvent.Failure -> throw event.throwable ?: Exception("MiMo TTS streaming failed")
+            is SseEvent.Failure -> {
+                val statusCode = event.response?.code
+                if (statusCode != null) {
+                    throw TTSProviderException(
+                        message = "MiMo TTS streaming failed: HTTP $statusCode",
+                        statusCode = statusCode,
+                        cause = event.throwable
+                    )
+                }
+                throw event.throwable ?: Exception("MiMo TTS streaming failed")
+            }
         }
     }
 }

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/MiniMaxTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/MiniMaxTTSProvider.kt
@@ -14,6 +14,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -124,6 +125,14 @@ class MiniMaxTTSProvider : TTSProvider<TTSProviderSetting.MiniMax> {
 
                 is SseEvent.Failure -> {
                     Log.e(TAG, "SSE connection failed", it.throwable)
+                    val statusCode = it.response?.code
+                    if (statusCode != null) {
+                        throw TTSProviderException(
+                            message = "MiniMax TTS streaming failed: HTTP $statusCode",
+                            statusCode = statusCode,
+                            cause = it.throwable
+                        )
+                    }
                     throw it.throwable ?: Exception("MiniMax TTS streaming failed")
                 }
             }

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/OpenAITTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/OpenAITTSProvider.kt
@@ -9,6 +9,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -48,7 +49,13 @@ class OpenAITTSProvider : TTSProvider<TTSProviderSetting.OpenAI> {
         val response = httpClient.newCall(httpRequest).execute()
 
         if (!response.isSuccessful) {
-            throw Exception("TTS request failed: ${response.code} ${response.message}")
+            val statusCode = response.code
+            val statusMessage = response.message
+            response.close()
+            throw TTSProviderException(
+                message = "TTS request failed: $statusCode $statusMessage",
+                statusCode = statusCode
+            )
         }
 
         val audioData = response.body.bytes()

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/QwenTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/QwenTTSProvider.kt
@@ -9,6 +9,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -63,7 +64,10 @@ class QwenTTSProvider : TTSProvider<TTSProviderSetting.Qwen> {
                     TAG,
                     "Qwen TTS request failed: ${response.code} ${response.message}, body: $errorBody"
                 )
-                throw Exception("Qwen TTS request failed: ${response.code} ${response.message}")
+                throw TTSProviderException(
+                    message = "Qwen TTS request failed: ${response.code} ${response.message}",
+                    statusCode = response.code
+                )
             }
 
             response.body.byteStream().bufferedReader().use { reader ->

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/StepTTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/StepTTSProvider.kt
@@ -10,6 +10,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -76,8 +77,9 @@ class StepTTSProvider : TTSProvider<TTSProviderSetting.Step> {
         if (!response.isSuccessful) {
             // 把错误响应体读出来方便排查 (4xx 通常返回 JSON 错误信息)
             val errorBody = runCatching { response.body?.string() }.getOrNull().orEmpty()
-            throw Exception(
-                "Step TTS request failed: HTTP ${response.code} ${response.message}. body=$errorBody"
+            throw TTSProviderException(
+                message = "Step TTS request failed: HTTP ${response.code} ${response.message}. body=$errorBody",
+                statusCode = response.code
             )
         }
 

--- a/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/XAITTSProvider.kt
+++ b/tts/src/main/java/com/eterultimate/eteruee/tts/provider/providers/XAITTSProvider.kt
@@ -8,6 +8,7 @@ import com.eterultimate.eteruee.tts.model.AudioChunk
 import com.eterultimate.eteruee.tts.model.AudioFormat
 import com.eterultimate.eteruee.tts.model.TTSRequest
 import com.eterultimate.eteruee.tts.provider.TTSProvider
+import com.eterultimate.eteruee.tts.provider.TTSProviderException
 import com.eterultimate.eteruee.tts.provider.TTSProviderSetting
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -49,7 +50,10 @@ class XAITTSProvider : TTSProvider<TTSProviderSetting.XAI> {
             val errorBody = response.body?.string()
             Log.e(TAG, "generateSpeech: ${response.code} ${response.message}")
             Log.e(TAG, "generateSpeech: $errorBody")
-            throw Exception("xAI TTS request failed: ${response.code} ${response.message}")
+            throw TTSProviderException(
+                message = "xAI TTS request failed: ${response.code} ${response.message}",
+                statusCode = response.code
+            )
         }
 
         val audioData = response.body.bytes()


### PR DESCRIPTION
## 概述

以 main (456b31b7e) 为基线，cherry-pick rikkahub 上游 **2026-08-28 19:14 (9851d0370) ~ 2026-09-04 18:44 (aac5e43e7)** 的修复与功能改进（17 个移植提交，全部 `-x` 标注上游来源）；对照 TauriTavern（main+dev）核查 roleplay 模块；扫描近期 commit/PR/issue 做有据修复。

## 一、修复类移植（上游 SHA）

- bf6fd994d fix: TTS 稳定性自动重试（5403bc960）
- 19c30881b fix: tts 重试判断细化（2f05019ba，FishAudio 因本仓库无该 provider 跳过）
- 2b522395b fix: cloudflare MCP OAuth 匹配（8ea375a93）
- 102d01947 chore: MCP SDK 改用 client-only artifact（ef94834a7，0.14.0 下解析验证通过）
- 23b706e6b fix: 移除硅基流动余额查询（1b9dd0923）
- 6f754bba8 fix: 代码块覆盖导出残留旧内容（5736c05ed）
- 0d5430681 + b0a80daf4 fix: 图片选择改用 PickVisualMedia 并恢复文件浏览入口（d3a53e0ad + 4b36640a9）
- 568a1f34e **fix(backup): 一致性快照 + 启动时安全恢复**（540b9dfaf）
- f348ba3ff fix: opencode 端点 x-opencode-session 头（5cdab9478）
- b47fc2ebf fix(i18n): 补全 TTS 播放倍速本地化（ec20570b6，键名适配为本仓库的 `setting_tts_page_playback_speed*`）

### 540b9dfaf 备份移植的 EterUee 适配

- AppDatabaseFactory：使用本仓库 BundledSQLiteDriver + MessageFtsSchema 回调 + 额外的 MIGRATION_17_18（上游为 Requery + libsimple/jieba）
- DatabaseBackup 完整性检查改用 framework SQLite（本仓库无 requery 依赖）；FTS 为 unicode61
- 无字体目录（20aa71b9b 从未移植），剔除 FONTS 备份项
- PreferencesStore 新增 restoreBeforeInitialization/persistSettings，键集按本仓库 saveSettings 镜像（含 POSTGRES_GATEWAY_CONFIG 等，无 FAST_MODEL 系）

## 二、功能类移植

- 4c38f056d feat(settings): 文件清理页新增范围清理（7da697707）
- 414d8d448 feat: 支持关闭自动重试（413535671，GenerationHandler + 网络设置页开关）
- bbd842b65 feat(search): 搜索范围切换 当前助手/全部助手（0f2c495b8）
  - EterUee 适配：本仓库 FTS 无 MessageSearchSort（上游排序特性未移植），改为在 `search(keyword, assistantId)` 上加 assistant 过滤（FTS 主路径 + LIKE 兜底路径均过滤），SearchVM 保留原防抖结构，DI 构造注入自动生效
- b1646ed09 chore: GPT-6 模型注册（c73f89724）
- f6b9bf2a1 chore: 移除记忆 id 显示（08c2648b5）

## 三、bug 扫描与修复

- b1d9b6d9e **fix(chat): ask_user 问答卡片容错解析与空答案提交守卫**
  - 证据：rikkahub#1848（2026-09-04，open）+ PR #1850（未合并）diff；本仓库 `ChatMessageTools.kt:979` 修复前解析逻辑与上游一致（单条畸形丢弃整列表 → 空白卡片；`questions.all{}` 空列表恒真 → 可提交空答案）
  - 修复对齐 PR #1850 模式并适配本仓库：容错解析双重编码/对象形 options、解析失败回退自由文本（`_raw`）、禁止空提交

## 四、roleplay 模块（TauriTavern 核查）

TauriTavern main 自 08-12 无变动；dev 08-25~09-04 共 75 个提交，逐个核查后**无可移植项**：
- agent 运行时/宏/QuickJS（PR #209、#216 等）：roleplay 无对应系统
- CodeMirror 编辑器、iframe 运行时、IME、跨 realm FormData、jqXHR：浏览器前端专属
- GB18030 ZIP 归档名修复（76b092b2）：roleplay 仅 PNG/JSON 导入，无 ZIP 归档导入
- GPT-6/GLM-5.3 等模型选项：roleplay 复用主 ai 模块（GPT-6 已随 c73f89724 进入注册表）
- x-opencode-session（TauriTavern#221）：已随 5cdab9478 从 rikkahub 侧移植

## 五、已核查后跳过（含依据）

| 上游提交 | 原因 |
| --- | --- |
| 9365c297a 快速模型思考级别 | 依赖 2026-05-31 cb36c3ee3 引入的 fastModel 架构（本仓库从未移植，保留独立标题/建议模型配置）；`titleModelId`/`suggestionModelId` 本仓库为非空且仍在使用 |
| f7869e353 gemini 混合工具错误修复 | 依赖未移植的 StreamChunk/StreamChunkHandler/ServerTool 架构（ai 模块重构族） |
| 0651cad9b 气泡透明度取整 | 本仓库无 bubbleOpacity 设置（未移植该特性），无修改目标 |
| 1231b8af1 加密 reasoning 测试修正 | 本仓库无 ResponseApiStreamDecoderTest（ai 模块结构不同） |
| 883bde7da TTS 倍速设置迁移 | 本仓库无 SettingPreferencesGeneralPage，设置结构不同 |
| aac5e43e7 workspace 图片缩略图 | 本仓库无 workspace 模块/页面结构 |
| f6a5330f2 trace-cli Google Interactions | 本仓库无 trace-cli 模块 |
| 5662945cf / 4309fdfe7 | 版本号 bump |
| b6df5f044 oauth 模块重构 | 结构性重构（新建 oauth/ 模块）；8ea375a93 已验证不依赖它 |

## 六、上游未修复、仅记录（证据不足，不做臆测修复）

- rikkahub#1857 退出后回答消失（open，无分析/修复提交）
- rikkahub#1852 批量工具审批误标拒绝、#1849 thinking 重渲染、#1845 世界书输入/注入计数（均 open，上游无修复）
- 未合并 PR #1759（tok/s 含工具执行时间）、#1854（Exa freshness）待上游合并后随下一轮移植

## 验证

- `:app:compileDebugKotlin` + `:ai/:tts/:search/:common/:roleplay/:app testDebugUnitTest` 全部通过
- 本 PR 不含版本号变更与发布；基于 main，与 #155（等审核中）无文件交集