### PR TITLE
release: bump 5.4.0 (versionCode 175)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 37
         versionCode = 174
-        versionName = "5.3.0"
+        versionName = "5.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.Locale
 
 private val desktopPackageName = "EterUee"
 private val desktopLinuxPackageName = "eteruee"
-private val desktopPackageVersion = "5.3.0"
+private val desktopPackageVersion = "5.4.0"
 private val hostOsName = System.getProperty("os.name").lowercase(Locale.ROOT)
 private val isWindowsHost = hostOsName.contains("win")
 private val isLinuxHost = hostOsName.contains("linux")


### PR DESCRIPTION
版本号 5.3.0 → **5.4.0**（versionCode 174 → 175），desktop 包版本同步 5.4.0。为 v5.4.0 发布准备；字节级替换避免 EOL churn。伴随 #156 的功能/修复批量进入，按 minor (+0.1.0) 递增。

## Summary by Sourcery

Build:
- Bump the Android and desktop packages to version 5.4.0, including Android versionCode 175.